### PR TITLE
Admin operations relatd APIs and its unit-test(nosetests)

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/admin/__init__.py
+++ b/tests/admin/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/admin/test_authdomain.py
+++ b/tests/admin/test_authdomain.py
@@ -1,0 +1,64 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.admin.authdomain import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_auth_domain_create():
+    auth_domain_create(handle, name="test_auth_dom", refresh_period="800")
+    found = auth_domain_exists(handle, name="test_auth_dom")[0]
+    assert_equal(found, True)
+
+
+def test_002_auth_domain_modify():
+    auth_domain_modify(handle, name="test_auth_dom", session_timeout="1000")
+    mo = auth_domain_realm_configure(
+        handle, domain_name="test_auth_dom", realm="ldap")
+    assert_equal(mo.realm, "ldap")
+
+
+def test_003_native_auth_configure():
+    native_authentication_configure(
+        handle, def_role_policy="assign-default-role", con_login="local")
+    mo = native_authentication_configure(handle, def_role_policy="no-login")
+    assert_equal(mo.def_role_policy, "no-login")
+
+
+def test_004_native_auth_default():
+    mo = native_authentication_default(handle, realm="radius")
+    assert_equal(mo.realm, "radius")
+    native_authentication_default(handle, realm="local")
+
+
+def test_005_native_auth_console():
+    mo = native_authentication_console(handle, realm="local")
+    assert_equal(mo.realm, "local")
+
+
+def test_006_auth_domain_delete():
+    auth_domain_delete(handle, name="test_auth_dom")
+    found = auth_domain_exists(handle, name="test_auth_dom")[0]
+    assert_equal(found, False)

--- a/tests/admin/test_callhome.py
+++ b/tests/admin/test_callhome.py
@@ -1,0 +1,53 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.admin.callhome import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_callhome_transport_gw_config():
+    mo = call_home_transport_gw_config(handle, enabled="true",
+                                       url="sch.gw.com")
+    assert_equal(mo.url, "sch.gw.com")
+
+
+def test_002_callhome_enable():
+    mo = call_home_enable(handle, alert_throttling_admin_state="on")
+    assert_equal(mo.alert_throttling_admin_state, "on")
+
+
+def test_003_callhome_config():
+    mo = call_home_config(handle, phone="+1-123456", urgency="warning")
+    assert_equal(mo.urgency, "warning")
+
+
+def test_004_callhome_proxy_config():
+    mo = call_home_proxy_config(handle, url="sch.proxycisco.com", port="80")
+    assert_equal(mo.url, "sch.proxycisco.com")
+
+
+def test_005_callhome_disable():
+    mo = call_home_disable(handle)
+    assert_equal(mo.admin_state, "off")

--- a/tests/admin/test_core_exporter.py
+++ b/tests/admin/test_core_exporter.py
@@ -1,0 +1,38 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.admin.core_exporter import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_core_exporter_enable():
+    mo = core_exporter_enable(handle, hostname="10.65.181.18", port="69",
+                              path="/root/tftp")
+    assert_equal(mo.port, "69")
+
+
+def test_002_core_exporter_disable():
+    mo = core_exporter_disable(handle)
+    assert_equal(mo.admin_state, "disabled")

--- a/tests/admin/test_dns.py
+++ b/tests/admin/test_dns.py
@@ -1,0 +1,44 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.admin.dns import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_dns_server_add():
+    dns_server_add(handle, name="2.2.2.2")
+    found = dns_server_exists(handle, name="2.2.2.2")[0]
+    assert_equal(found, True)
+
+
+def test_002_dns_set_domain_name():
+    mo = dns_set_domain_name(handle, domain="cisco.com")
+    assert_equal(mo.domain, "cisco.com")
+
+
+def test_003_dns_server_remove():
+    dns_server_remove(handle, name="2.2.2.2")
+    found = dns_server_exists(handle, name="2.2.2.2")[0]
+    assert_equal(found, False)

--- a/tests/admin/test_keyring.py
+++ b/tests/admin/test_keyring.py
@@ -1,0 +1,76 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.admin.keyring import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_keyring_create():
+    key_ring_create(handle, "test_kr")
+    found = key_ring_exists(handle, name="test_kr")[0]
+    assert_equal(found, True)
+
+
+def test_002_keyring_modify():
+    mo = key_ring_modify(handle, name="test_kr", regen="true")
+    assert_equal(mo.regen, "yes")
+
+
+def test_003_certificate_add():
+    certificate_request_add(handle, name="test_kr", dns="10.10.10.100",
+                            country="IN")
+    found, mo = certificate_request_exists(handle, name="test_kr",
+                                           dns="10.10.10.100")
+    assert_equal(found, True)
+    assert_equal(mo.dns, "10.10.10.100")
+
+
+def test_004_trusted_point_create():
+    trusted_point_create(handle, "test_tp")
+    found = trusted_point_exists(handle, name="test_tp")[0]
+    assert_equal(found, True)
+
+
+def test_005_trusted_point_modify():
+    mo = trusted_point_modify(handle, name="test_tp", descr="testing tp")
+    assert_equal(mo.descr, "testing tp")
+
+
+def test_006_trusted_point_delete():
+    trusted_point_delete(handle, "test_tp")
+    found = trusted_point_exists(handle, name="test_tp")[0]
+    assert_equal(found, False)
+
+
+def test_007_certificate_remove():
+    certificate_request_remove(handle, name="test_kr")
+    found = certificate_request_exists(handle, name="test_kr")[0]
+    assert_equal(found, False)
+
+
+def test_008_keyring_delete():
+    key_ring_delete(handle, "test_kr")
+    found = key_ring_exists(handle, name="test_kr")[0]
+    assert_equal(found, False)

--- a/tests/admin/test_ldap.py
+++ b/tests/admin/test_ldap.py
@@ -1,0 +1,120 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.admin.ldap import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_ldap_provider_create():
+
+    ldap_provider_create(handle, name="test_ldap_prov", port="320", order="3")
+    found = ldap_provider_exists(handle, name="test_ldap_prov", port="320",
+                                 order="3")[0]
+    assert_equal(found, True)
+
+
+def test_002_ldap_provider_modify():
+    mo = ldap_provider_modify(handle, name="test_ldap_prov", enable_ssl="yes")
+    assert_equal(mo.enable_ssl, "yes")
+
+
+def test_003_ldap_provider_configure_rules():
+    mo = ldap_provider_configure_group_rules(
+            handle,
+            ldap_provider_name="test_ldap_prov", authorization="enable")
+    assert_equal(mo.authorization, "enable")
+
+
+def test_004_ldap_group_map_create():
+    ldap_group_map_create(handle, name="test_ldap_grp_map")
+    found = ldap_group_map_exists(handle, name="test_ldap_grp_map")[0]
+    assert_equal(found, True)
+
+
+def test_005_ldap_group_map_add_role():
+    ldap_group_map_add_role(
+        handle, ldap_group_map_name="test_ldap_grp_map", name="storage")
+    found = ldap_group_map_role_exists(
+            handle,
+            ldap_group_map_name="test_ldap_grp_map", name="storage")[0]
+    assert_equal(found, True)
+
+
+def test_006_ldap_provider_group_create():
+    ldap_provider_group_create(handle, name="test_prov_grp")
+    found = ldap_provider_group_exists(handle, name="test_prov_grp")[0]
+    assert_equal(found, True)
+
+
+def test_007_ldap_provider_group_add_provider():
+    ldap_provider_group_add_provider(
+        handle, group_name="test_prov_grp", name="test_ldap_prov")
+    found = ldap_provider_group_provider_exists(
+            handle,
+            group_name="test_prov_grp", name="test_ldap_prov")[0]
+    assert_equal(found, True)
+
+
+def test_008_ldap_provider_group_modify_provider():
+    mo = ldap_provider_group_modify_provider(
+        handle, group_name="test_prov_grp", name="test_ldap_prov",
+        order="2")
+    assert_equal(mo.order, "2")
+
+
+def test_009_ldap_provider_group_remove_provider():
+    ldap_provider_group_remove_provider(
+        handle, group_name="test_prov_grp", name="test_ldap_prov")
+    found = ldap_provider_group_provider_exists(
+            handle,
+            group_name="test_prov_grp", name="test_ldap_prov")[0]
+    assert_equal(found, False)
+
+
+def test_010_ldap_provider_group_delete():
+    ldap_provider_group_delete(handle, name="test_prov_grp")
+    found = ldap_provider_group_exists(handle, name="test_prov_grp")[0]
+    assert_equal(found, False)
+
+
+def test_011_ldap_group_map_remove_role():
+    ldap_group_map_remove_role(
+        handle, ldap_group_map_name="test_ldap_grp_map", name="storage")
+    found = ldap_group_map_role_exists(
+            handle,
+            ldap_group_map_name="test_ldap_grp_map", name="storage")[0]
+    assert_equal(found, False)
+
+
+def test_012_ldap_group_map_delete():
+    ldap_group_map_delete(handle, name="test_ldap_grp_map")
+    found = ldap_group_map_exists(handle, name="test_ldap_grp_map")[0]
+    assert_equal(found, False)
+
+
+def test_013_ldap_provider_delete():
+    ldap_provider_delete(handle, name="test_ldap_prov")
+    found = ldap_provider_exists(handle, name="test_ldap_prov")[0]
+    assert_equal(found, False)

--- a/tests/admin/test_locale.py
+++ b/tests/admin/test_locale.py
@@ -1,0 +1,56 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.admin.locale import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_locale_create():
+    locale_create(handle, name="test_locale")
+    found = locale_exists(handle, name="test_locale")[0]
+    assert_equal(found, True)
+
+
+def test_002_locale_modify():
+    mo = locale_modify(handle, name="test_locale", descr="testing locale")
+    assert_equal(mo.descr, "testing locale")
+
+
+def test_003_locale_assign_org():
+    mo = locale_assign_org(handle, locale_name="test_locale",
+                           name="test_org_assign")
+    assert_equal(mo.name, "test_org_assign")
+
+
+def test_004_locale_assign_domaingroup():
+    mo = locale_assign_domaingroup(handle, locale_name="test_locale",
+                                   name="test_domgrp_asn")
+    assert_equal(mo.name, "test_domgrp_asn")
+
+
+def test_005_locale_delete():
+    locale_delete(handle, name="testlocale")
+    found = locale_exists(handle, name="testlocale")[0]
+    assert_equal(found, False)

--- a/tests/admin/test_radius.py
+++ b/tests/admin/test_radius.py
@@ -1,0 +1,83 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.admin.radius import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_radius_provider_create():
+    radius_provider_create(handle, name="test_radius_prov",
+                           auth_port="320", timeout="10")
+    found = radius_provider_exists(handle, name="test_radius_prov",
+                                   auth_port="320")[0]
+    assert_equal(found, True)
+
+
+def test_002_radius_provider_modify():
+    mo = radius_provider_modify(handle, name="test_radius_prov", timeout="5")
+    assert_equal(mo.timeout, "5")
+
+
+def test_003_radius_provider_group_create():
+    radius_provider_group_create(handle, name="test_prov_grp")
+    found = radius_provider_group_exists(handle, name="test_prov_grp")[0]
+    assert_equal(found, True)
+
+
+def test_004_radius_provider_group_add_provider():
+    radius_provider_group_add_provider(
+        handle, group_name="test_prov_grp", name="test_radius_prov")
+    found = radius_provider_group_provider_exists(
+            handle,
+            group_name="test_prov_grp", name="test_radius_prov")[0]
+    assert_equal(found, True)
+
+
+def test_005_radius_provider_group_modify_provider():
+    mo = radius_provider_group_modify_provider(
+        handle, group_name="test_prov_grp", name="test_radius_prov",
+        order="2")
+    assert_equal(mo.order, "2")
+
+
+def test_006_radius_provider_group_remove_provider():
+    radius_provider_group_remove_provider(
+        handle, group_name="test_prov_grp", name="test_radius_prov")
+    found = radius_provider_group_provider_exists(
+            handle,
+            group_name="test_prov_grp", name="test_radius_prov")[0]
+    assert_equal(found, False)
+
+
+def test_007_radius_provider_group_delete():
+    radius_provider_group_delete(handle, name="test_prov_grp")
+    found = radius_provider_group_exists(handle, name="test_prov_grp")[0]
+    assert_equal(found, False)
+
+
+def test_008_radius_provider_delete():
+    radius_provider_delete(handle, name="test_radius_prov")
+    found = radius_provider_exists(handle, name="test_radius_prov")[0]
+    assert_equal(found, False)

--- a/tests/admin/test_role.py
+++ b/tests/admin/test_role.py
@@ -1,0 +1,44 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.admin.role import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_role_create():
+    role_create(handle, name="test_role", priv="admin")
+    found = role_exists(handle, name="test_role", priv="admin")[0]
+    assert_equal(found, True)
+
+
+def test_002_role_modify():
+    mo = role_modify(handle, name="test_role", priv="read-only")
+    assert_equal(mo.priv, "read-only")
+
+
+def test_003_role_delete():
+    role_delete(handle, name="test_role")
+    found = role_exists(handle, name="test_role")[0]
+    assert_equal(found, False)

--- a/tests/admin/test_snmp.py
+++ b/tests/admin/test_snmp.py
@@ -1,0 +1,72 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.admin.snmp import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_snmp_enable():
+    mo = snmp_enable(handle, community="public", sys_contact="+001-12345678")
+    assert_equal(mo.sys_contact, "+001-12345678")
+
+
+def test_002_snmp_trap_add():
+    snmp_trap_add(handle, hostname="3.3.3.3", community="public")
+    found = snmp_trap_exists(handle, hostname="3.3.3.3")[0]
+    assert_equal(found, True)
+
+
+def test_003_snmp_trap_modify():
+    mo = snmp_trap_modify(handle, hostname="3.3.3.3", version="v3")
+    assert_equal(mo.version, "v3")
+
+
+def test_004_snmp_user_add():
+    snmp_user_add(handle, name="usr_snmp",
+                  pwd="pwd#*22345", privpwd="pwd#*3456")
+    found = snmp_user_exists(handle, name="usr_snmp")[0]
+    assert_equal(found, True)
+
+
+def test_005_snmp_user_modify():
+    mo = snmp_user_modify(handle, name="usr_snmp", auth="sha")
+    assert_equal(mo.auth, "sha")
+
+
+def test_006_snmp_user_remove():
+    snmp_user_remove(handle, name="usr_snmp")
+    found = snmp_user_exists(handle, name="usr_snmp")[0]
+    assert_equal(found, False)
+
+
+def test_007_snmp_trap_remove():
+    snmp_trap_remove(handle, hostname="3.3.3.3")
+    found = snmp_trap_exists(handle, hostname="3.3.3.3")[0]
+    assert_equal(found, False)
+
+
+def test_008_snmp_trap_remove():
+    mo = snmp_disable(handle)
+    assert_equal(mo.admin_state, "disabled")

--- a/tests/admin/test_syslog.py
+++ b/tests/admin/test_syslog.py
@@ -1,0 +1,73 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.admin.syslog import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_syslog_local_console_enable():
+    mo = syslog_local_console_enable(handle, severity="alerts")
+    assert_equal(mo.severity, "alerts")
+
+
+def test_002_syslog_local_monitor_enable():
+    mo = syslog_local_monitor_enable(handle, severity="emergencies")
+    assert_equal(mo.severity, "emergencies")
+
+
+def test_003_syslog_local_file_enable():
+    mo = syslog_local_file_enable(handle, name="test_syslog", size="10000")
+    assert_equal(mo.size, "10000")
+
+
+def test_004_syslog_remote_enable():
+    mo = syslog_remote_enable(handle, name="primary", hostname="192.168.1.2",
+                              forwarding_facility="local3")
+    assert_equal(mo.forwarding_facility, "local3")
+
+
+def test_005_syslog_source():
+    mo = syslog_source(handle, faults="enabled", events="enabled")
+    assert_equal(mo.faults, "enabled")
+
+
+def test_006_remote_disable():
+    mo = syslog_remote_disable(handle, name="primary")
+    assert_equal(mo.admin_state, "disabled")
+
+
+def test_007_local_monitor_disable():
+    mo = syslog_local_monitor_disable(handle)
+    assert_equal(mo.admin_state, "disabled")
+
+
+def test_008_local_file_disable():
+    mo = syslog_local_file_disable(handle)
+    assert_equal(mo.admin_state, "disabled")
+
+
+def test_009_local_console_disable():
+    mo = syslog_local_console_disable(handle)
+    assert_equal(mo.admin_state, "disabled")

--- a/tests/admin/test_tacacsplus.py
+++ b/tests/admin/test_tacacsplus.py
@@ -1,0 +1,84 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.admin.tacacsplus import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_tacacsplus_provider_create():
+    tacacsplus_provider_create(
+        handle, name="test_tacac_prov", port="320", timeout="10")
+    found = tacacsplus_provider_exists(
+        handle, name="test_tacac_prov", port="320")[0]
+    assert_equal(found, True)
+
+
+def test_002_tacacsplus_provider_modify():
+    mo = tacacsplus_provider_modify(
+        handle, name="test_tacac_prov", timeout="5")
+    assert_equal(mo.timeout, "5")
+
+
+def test_003_tacacsplus_provider_group_create():
+    tacacsplus_provider_group_create(handle, name="test_prov_grp")
+    found = tacacsplus_provider_group_exists(handle, name="test_prov_grp")[0]
+    assert_equal(found, True)
+
+
+def test_004_tacacsplus_provider_group_add_provider():
+    tacacsplus_provider_group_add_provider(
+        handle, group_name="test_prov_grp", name="test_tacac_prov")
+    found = tacacsplus_provider_group_provider_exists(
+            handle,
+            group_name="test_prov_grp", name="test_tacac_prov")[0]
+    assert_equal(found, True)
+
+
+def test_005_tacacsplus_provider_group_modify_provider():
+    mo = tacacsplus_provider_group_modify_provider(
+        handle, group_name="test_prov_grp", name="test_tacac_prov",
+        order="2")
+    assert_equal(mo.order, "2")
+
+
+def test_006_tacacsplus_provider_group_remove_provider():
+    tacacsplus_provider_group_remove_provider(
+        handle, group_name="test_prov_grp", name="test_tacac_prov")
+    found = tacacsplus_provider_group_provider_exists(
+            handle,
+            group_name="test_prov_grp", name="test_tacac_prov")[0]
+    assert_equal(found, False)
+
+
+def test_007_tacacsplus_provider_group_delete():
+    tacacsplus_provider_group_delete(handle, name="test_prov_grp")
+    found = tacacsplus_provider_group_exists(handle, name="test_prov_grp")[0]
+    assert_equal(found, False)
+
+
+def test_008_tacacsplus_provider_delete():
+    tacacsplus_provider_delete(handle, name="test_tacac_prov")
+    found = tacacsplus_provider_exists(handle, name="test_tacac_prov")[0]
+    assert_equal(found, False)

--- a/tests/admin/test_timezone.py
+++ b/tests/admin/test_timezone.py
@@ -1,0 +1,44 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.admin.timezone import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_timezone_set():
+    mo = time_zone_set(handle, timezone="Asia/Manila")
+    assert_equal(mo.timezone, "Asia/Manila")
+
+
+def test_002_ntp_server_create():
+    ntp_server_create(handle, name="192.168.1.1")
+    found = ntp_server_exists(handle, name="192.168.1.1")[0]
+    assert_equal(found, True)
+
+
+def test_003_ntp_server_remove():
+    ntp_server_remove(handle, name="192.168.1.1")
+    found = ntp_server_exists(handle, name="192.168.1.1")[0]
+    assert_equal(found, False)

--- a/tests/admin/test_user.py
+++ b/tests/admin/test_user.py
@@ -1,0 +1,103 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.admin.user import *
+from ucsc_apis.admin.locale import *
+import random
+import string
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def random_string(length):
+    return ''.join(random.choice(string.ascii_letters)
+                   for ii in range(length + 1))
+
+
+def test_001_user_create():
+    user_create(handle, name="test_user",
+                first_name="testuser", pwd=random_string(8))
+    found = user_exists(handle, name="test_user", first_name="testuser")[0]
+    assert_equal(found, True)
+
+
+def test_002_user_modify():
+    mo = user_modify(handle, name="test_user", last_name="test lastname")
+    assert_equal(mo.last_name, "test lastname")
+
+
+def test_003_user_add_role():
+    user_add_role(handle, user_name="test_user", name="storage")
+    found = user_role_exists(handle, user_name="test_user", name="storage")[0]
+    assert_equal(found, True)
+
+
+def test_004_user_remove_role():
+    user_remove_role(handle, user_name="test_user", name="storage")
+    found = user_role_exists(handle, user_name="test_user", name="storage")[0]
+    assert_equal(found, False)
+
+
+def test_005_locale_create():
+    locale_create(handle, name="testlocale")
+    found = locale_exists(handle, name="testlocale")[0]
+    assert_equal(found, True)
+
+
+def test_006_user_add_locale():
+    user_add_locale(handle, user_name="test_user", name="testlocale")
+    found = user_locale_exists(handle, user_name="test_user",
+                               name="testlocale")[0]
+    assert_equal(found, True)
+
+
+def test_007_user_remove_locale():
+    user_remove_locale(handle, user_name="test_user", name="testlocale")
+    found = user_locale_exists(handle, user_name="test_user",
+                               name="testlocale")[0]
+    assert_equal(found, False)
+
+
+def test_008_locale_delete():
+    locale_delete(handle, name="testlocale")
+    found = locale_exists(handle, name="testlocale")[0]
+    assert_equal(found, False)
+
+
+def test_009_password_strength_check():
+    mo = password_strength_check(handle)
+    assert_equal(mo.pwd_strength_check, "yes")
+    mo = password_strength_uncheck(handle)
+    assert_equal(mo.pwd_strength_check, "no")
+
+
+def test_010_password_profile_modify():
+    mo = password_profile_modify(handle, change_count="3")
+    assert_equal(mo.change_count, "3")
+
+
+def test_011_user_delete():
+    user_delete(handle, name="test_user")
+    found = user_exists(handle, name="test_user", first_name="testuser")[0]
+    assert_equal(found, False)

--- a/tests/connection/__init__.py
+++ b/tests/connection/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tests/connection/connection.cfg
+++ b/tests/connection/connection.cfg
@@ -1,0 +1,4 @@
+[ucscentral]
+hostname=10.105.219.134
+username=admin
+password=Nbv12345

--- a/tests/connection/info.py
+++ b/tests/connection/info.py
@@ -1,0 +1,43 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+host = "ucscentral"
+
+
+def custom_setup():
+    try:
+        import ConfigParser
+    except:
+        import configparser as ConfigParser
+
+    import os
+    from ucscsdk.ucschandle import UcscHandle
+
+    config = ConfigParser.RawConfigParser()
+    config.read(os.path.join(os.path.dirname(__file__), '..', 'connection',
+                             'connection.cfg'))
+
+    hostname = config.get(host, "hostname")
+    username = config.get(host, "username")
+    password = config.get(host, "password")
+    try:
+        port = config.get(host, "port")
+    except:
+        port = 443
+    handle = UcscHandle(hostname, username, password, port=port)
+    handle.login()
+    return handle
+
+
+def custom_teardown(handle):
+    handle.logout()

--- a/ucsc_apis/__init__.py
+++ b/ucsc_apis/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/ucsc_apis/admin/__init__.py
+++ b/ucsc_apis/admin/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/ucsc_apis/admin/authdomain.py
+++ b/ucsc_apis/admin/authdomain.py
@@ -1,0 +1,331 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs the operation related to Authentication management.
+"""
+ucsc_base_dn = "org-root/deviceprofile-default"
+
+
+def auth_domain_create(handle, name, refresh_period="600",
+                       session_timeout="7200", descr="", **kwargs):
+    """
+    Adds a auth domain
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of auth domain
+        refresh_period: refresh period in seconds. Default 600.
+        session_timeout: timeout in seconds. Default 7200.
+        descr (string): description
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+
+    Returns:
+        AaaDomain : Managed Object
+
+    Example:
+        auth_domain_create(handle, name="ciscoucscentral")
+    """
+    from ucscsdk.mometa.aaa.AaaDomain import AaaDomain
+
+    mo = AaaDomain(parent_mo_or_dn=ucsc_base_dn + "/auth-realm",
+                   name=name,
+                   refresh_period=refresh_period,
+                   session_timeout=session_timeout,
+                   descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def auth_domain_exists(handle, name, **kwargs):
+    """
+    checks if auth domain exists
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of auth domain
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        auth_domain_exists(handle, name="ciscoucscentral")
+    """
+
+    dn = ucsc_base_dn + "/auth-realm/domain-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def auth_domain_modify(handle, name, **kwargs):
+    """
+    Modifies a domain
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of domain
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        AaaDomain : Managed Object
+
+    Raises:
+        ValueError: If AaaDomain is not present
+
+    Example:
+        auth_domain_modify(handle, name="ciscoucscentral", descr="modified")
+    """
+
+    dn = ucsc_base_dn + "/auth-realm/domain-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Auth Domain '%s' does not exist." % dn)
+
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def auth_domain_delete(handle, name):
+    """
+    deletes a auth domain.
+
+    Args:
+        handle (UcscHandle)
+        name (string): auth domain name
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaDomain is not present
+
+    Example:
+        auth_domain_delete(handle, name="ciscoucscentral")
+    """
+
+    dn = ucsc_base_dn + "/auth-realm/domain-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Auth Domain '%s' does not exist." % dn)
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def auth_domain_realm_configure(handle, domain_name, realm="local",
+                                provider_group="", name="", descr="",
+                                **kwargs):
+    """
+    configure realm of a auth domain.
+
+    Args:
+        handle (UcscHandle)
+        domain_name (string): auth domain name
+        realm (string): realm ["ldap", "local", "none", "radius", "tacacs"]
+        provider_group (string): provider group name
+        name (string): name
+        descr (string): description
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+
+    Returns:
+        AaaDomainAuth : Managed Object
+
+    Raises:
+        ValueError: If AaaDomain is not present
+
+    Example:
+        auth_domain_realm_configure(handle, domain_name="ciscoucscentral",
+                                    realm="ldap")
+    """
+
+    from ucscsdk.mometa.aaa.AaaDomainAuth import AaaDomainAuth
+
+    dn = ucsc_base_dn + "/auth-realm/domain-" + domain_name
+    obj = handle.query_dn(dn)
+    if not obj:
+        raise ValueError("Auth Domain '%s' does not exist" % dn)
+
+    mo = AaaDomainAuth(parent_mo_or_dn=obj, name=name, descr=descr,
+                       realm=realm, provider_group=provider_group)
+
+    if kwargs:
+        mo.set_prop_multiple(kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def native_authentication_configure(handle, def_role_policy=None,
+                                    def_login=None, con_login=None,
+                                    descr=None, **kwargs):
+    """
+    configure native authentication.
+
+    Args:
+        handle (UcscHandle)
+        def_role_policy (string): def_role_policy
+        def_login (string): def_login
+        con_login (string): con_login
+        descr (string): description
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+
+    Returns:
+        AaaAuthRealm : Managed Object
+
+    Raises:
+        ValueError: If AaaAuthRealm is not present
+
+    Example:
+        native_authentication_configure(handle, descr="modified")
+    """
+
+    mo = handle.query_dn(ucsc_base_dn + "/auth-realm")
+    if not mo:
+        raise ValueError("Native Authentication does not exist.")
+
+    if def_role_policy:
+        mo.def_role_policy = def_role_policy
+    if def_login:
+        mo.def_login = def_login
+    if con_login:
+        mo.con_login = con_login
+    if descr:
+        mo.descr = descr
+
+    if kwargs:
+        mo.set_prop_multiple(kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def native_authentication_default(handle, realm=None, session_timeout=None,
+                                  refresh_period=None, provider_group=None,
+                                  name=None, descr=None, **kwargs):
+    """
+    configure default native authentication.
+
+    Args:
+        handle (UcscHandle)
+        realm (string): realm
+        session_timeout (string): session_timeout
+        refresh_period (string): refresh_period
+        provider_group (string): provider_group
+        name (string): name
+        descr (string): description
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaDefaultAuth : Managed Object
+
+    Raises:
+        ValueError: If AaaDefaultAuth is not present
+
+    Example:
+        native_authentication_default(handle, descr="modified")
+    """
+
+    mo = handle.query_dn(
+        ucsc_base_dn + "/auth-realm/default-auth")
+    if not mo:
+        raise ValueError("Native Default Authentication does not exist")
+
+    if realm:
+        mo.realm = realm
+    if session_timeout:
+        mo.session_timeout = session_timeout
+    if refresh_period:
+        mo.refresh_period = refresh_period
+    if provider_group:
+        mo.provider_group = provider_group
+    if name:
+        mo.name = name
+    if descr:
+        mo.descr = descr
+
+    if kwargs:
+        mo.set_prop_multiple(kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def native_authentication_console(handle, realm=None, provider_group=None,
+                                  name=None, descr=None, **kwargs):
+    """
+    configure console native authentication.
+
+    Args:
+        handle (UcscHandle)
+        realm (string): realm
+        provider_group (string): provider_group
+        name (string): name
+        descr (string): description
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaConsoleAuth : Managed Object
+
+    Raises:
+        ValueError: If AaaConsoleAuth is not present
+
+    Example:
+        native_authentication_console(handle, descr="modified")
+    """
+
+    mo = handle.query_dn(
+        ucsc_base_dn + "/auth-realm/console-auth")
+    if not mo:
+        raise ValueError("Native Console Authentication does not exist")
+
+    if realm:
+        mo.realm = realm
+    if provider_group:
+        mo.provider_group = provider_group
+    if name:
+        mo.name = name
+    if descr:
+        mo.descr = descr
+
+    if kwargs:
+        mo.set_prop_multiple(kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo

--- a/ucsc_apis/admin/callhome.py
+++ b/ucsc_apis/admin/callhome.py
@@ -1,0 +1,247 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs the operation related to callhome.
+"""
+ucsc_base_dn = "org-root/deviceprofile-default"
+
+
+def call_home_enable(handle, alert_throttling_admin_state=None, name="",
+                     descr="", **kwargs):
+    """
+    Enables call home alert.
+
+    Args:
+        handle (UcscHandle)
+        alert_throttling_admin_state (string): "on" or "off"
+        name (string): name
+        descr (string): description
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        CallhomeEp : ManagedObject
+
+    Raises:
+        ValueError: If CallhomeEp is not present
+
+    Example:
+        call_home_state_enable(handle)
+    """
+
+    mo = handle.query_dn(ucsc_base_dn + "/call-home")
+    if not mo:
+        raise ValueError("Call home not available.")
+
+    mo.admin_state = "on"
+    if alert_throttling_admin_state is not None:
+        mo.alert_throttling_admin_state = alert_throttling_admin_state
+    mo.name = name
+    mo.descr = descr
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def call_home_config(handle, contact=None, phone=None, email=None,
+                     addr=None, customer=None, contract=None, site=None,
+                     r_from=None, reply_to=None, urgency=None, **kwargs):
+    """
+    Configures call home
+
+    Args:
+        handle (UcscHandle)
+        contact (string): Contact Name
+        phone (string): phone number e.g. +91-1234567890
+        email (string): contact email address
+        addr (string): contact address
+        customer (number): customer id
+        contract (number): contract id
+        site (number): site id
+        r_from (string): from email address
+        reply_to (string): to email address
+        urgency (string): alert priority
+         valid values are "alert", "critical", "debug", "emergency",
+         "error", "info", "notice", "warning"
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        SmartcallhomeSource: ManagedObject
+
+    Raises:
+        ValueError: If SmartcallhomeSource is not present
+
+    Example:
+        from ucscsdk.mometa.callhome.SmartcallhomeSource import \
+            SmartcallhomeSourceConsts
+
+        call_home_config(handle,
+                         contact="user name",
+                         phone="+91-1234567890",
+                         email="user@cisco.com",
+                         addr="user address",
+                         customer="1111",
+                         contract="2222",
+                         site="3333",
+                         r_from="from@cisco.com",
+                         reply_to="to@cisco.com",
+                         urgency=CallhomeSourceConsts.URGENCY_ALERT,
+                         )
+    """
+
+    # configure call home
+    dn = ucsc_base_dn + "/call-home/sch-source"
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Call home source '%s' not available." % dn)
+
+    if contact:
+        mo.contact = contact
+    if phone:
+        mo.phone = phone
+    if email:
+        mo.email = email
+    if addr:
+        mo.addr = addr
+    if customer:
+        mo.customer = customer
+    if contract:
+        mo.contract = contract
+    if site:
+        mo.site = site
+    if r_from:
+        mo.r_from = r_from
+    if reply_to:
+        mo.reply_to = reply_to
+    if urgency:
+        mo.urgency = urgency
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def call_home_disable(handle):
+    """
+    Disables call home alert.
+
+    Args:
+        handle (UcscHandle)
+
+    Returns:
+        CallhomeEp : ManagedObject
+
+    Raises:
+        ValueError: If CallhomeEp is not present
+
+    Example:
+        call_home_state_disable(handle)
+    """
+
+    mo = handle.query_dn(ucsc_base_dn + "/call-home")
+    if not mo:
+        raise ValueError("Call home not available.")
+
+    mo.admin_state = "off"
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def call_home_proxy_config(handle, url, port="80", **kwargs):
+    """
+    Configures HTTP proxy for callhome
+
+    Args:
+        handle (UcscHandle)
+        url (String) : URL for the call home proxy
+        port (String) : port number for the call home proxy
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        SmartcallhomeHttpProxy : ManagedObject
+
+    Raises:
+        ValueError: If SmartcallhomeHttpProxy is not present
+
+    Example:
+        call_home_proxy_config(handle, url="www.testproxy.com", port=80)
+    """
+
+    mo = handle.query_dn(ucsc_base_dn + "/call-home/proxy")
+    if not mo:
+        raise ValueError("call home proxy is not available.")
+
+    mo.url = url
+    mo.port = port
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def call_home_transport_gw_config(handle, enabled, url, certificate=None,
+                                  **kwargs):
+    """
+    Configures HTTP transport gateway for callhome
+
+    Args:
+        handle (UcscHandle)
+        enabled (Boolean) : Transport gw is enabled or not, True or False
+        url (String) : URL for the transport gw
+        certificate (String): Certificate for the transport gw
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        SmartcallhomeTransportGateway : ManagedObject
+
+    Raises:
+        ValueError: If SmartcallhomeTransportGateway is not present
+
+    Example:
+        call_home_proxy_config(handle, enabled = True,
+                               url="www.testtrasportgw.com")
+    """
+
+    mo = handle.query_dn(
+        ucsc_base_dn + "/call-home/transport-gateway")
+    if not mo:
+        raise ValueError("call home transport gw is not available.")
+
+    mo.enabled = enabled
+    mo.url = url
+
+    if certificate is not None:
+        mo.cert_chain = certificate
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo

--- a/ucsc_apis/admin/core_exporter.py
+++ b/ucsc_apis/admin/core_exporter.py
@@ -1,0 +1,85 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ucsc_base_dn = "org-root/deviceprofile-default"
+
+
+def core_exporter_enable(handle,
+                         hostname,
+                         path,
+                         port,
+                         descr="",
+                         **kwargs):
+    """
+    This method configures UCS Central tftp core exporter.
+
+    Args:
+        handle (UcscHandle)
+        hostname (string): IP or Hostname of server.
+        path (string): Absolute path where core files are to be stored.
+        port (string): Port number of tftp exporter
+        descr (string): Basic description about configuration.
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+
+    Returns:
+        SysdebugAutoCoreFileExportTarget: ManagedObject
+
+    Example:
+        mo = core_exporter_enable(handle,hostname="10.65.180.18",
+                port="69", path="/root/tftp")
+    """
+
+    from ucscsdk.mometa.sysdebug.SysdebugAutoCoreFileExportTarget import\
+        SysdebugAutoCoreFileExportTarget
+
+    mo = SysdebugAutoCoreFileExportTarget(
+        parent_mo_or_dn=ucsc_base_dn,
+        descr=descr,
+        hostname=hostname,
+        admin_state="enabled",
+        path=path, port=port)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def core_exporter_disable(handle):
+    """
+    This method disables UCS Central tftp core exporter.
+
+    Args:
+        handle (UcscHandle)
+
+    Returns:
+        SysdebugAutoCoreFileExportTarget: ManagedObject
+
+    Example:
+        core_exporter_disable(handle)
+    """
+
+    from ucscsdk.mometa.sysdebug.SysdebugAutoCoreFileExportTarget import\
+        SysdebugAutoCoreFileExportTarget
+
+    mo = SysdebugAutoCoreFileExportTarget(
+        parent_mo_or_dn=ucsc_base_dn,
+        admin_state="disabled")
+
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo

--- a/ucsc_apis/admin/dns.py
+++ b/ucsc_apis/admin/dns.py
@@ -1,0 +1,137 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs the operation related to dns server management.
+"""
+ucsc_base_dn = "org-root/deviceprofile-default"
+
+
+def dns_server_add(handle, name, descr="", **kwargs):
+    """
+    Adds a dns server
+
+    Args:
+        handle (UcscHandle)
+        descr (string): description
+        name (string): IP Address of dns server
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        CommDnsProvider: Managed object
+
+    Example:
+        mo = dns_server_add(handle, name="8.8.8.8", descr="dns_google")
+    """
+
+    from ucscsdk.mometa.comm.CommDnsProvider import CommDnsProvider
+
+    mo = CommDnsProvider(
+        parent_mo_or_dn=ucsc_base_dn + "/dns-svc",
+        name=name,
+        descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def dns_server_remove(handle, name):
+    """
+    Removes a dns server
+
+    Args:
+        handle (UcscHandle)
+        name (string): IP Address of the dns server
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If CommDnsProvider is not present
+
+    Example:
+        dns_server_remove(handle, "10.10.10.10")
+    """
+
+    dn = ucsc_base_dn + "/dns-svc/dns-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("dns server '%s' not found" % dn)
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def dns_server_exists(handle, name, **kwargs):
+    """
+    Checks if the dns entry already exists
+
+    Args:
+        handle (UcscHandle)
+        name (string): IP address of the dns server
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        bool_var = dns_server_exists(handle, "10.10.10.10")
+    """
+
+    dn = ucsc_base_dn + "/dns-svc/dns-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def dns_set_domain_name(handle, domain, **kwargs):
+    """
+    Sets the Ucs Central domain name for dns
+
+    Args:
+        handle (UcscHandle)
+        domain (string): Domain name
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        CommDns : Managed Object
+
+    Raises:
+        ValueError: If CommDns is not present
+
+    Example:
+        dns_set_domain_name(handle, "cisco.com")
+    """
+
+    dn = ucsc_base_dn + "/dns-svc"
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("dns MO doesn't exist")
+    mo.domain = domain
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo

--- a/ucsc_apis/admin/keyring.py
+++ b/ucsc_apis/admin/keyring.py
@@ -1,0 +1,396 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs the operation related to key management.
+"""
+ucsc_base_dn = "org-root/deviceprofile-default"
+
+
+def key_ring_create(handle, name, descr="", tp="",
+                    cert="", regen="no", modulus="mod2048", **kwargs):
+    """
+    Creates a key ring
+
+    Args:
+        handle (ucschandle)
+        name (string): name
+        descr (string): description
+        tp (string): tp
+        cert (string): certificate
+        regen (string): regen, "false", "no", "true", "yes"
+        modulus (string): modulus, valid values are
+            "mod2048", "mod2560", "mod3072", "mod3584", "mod4096", "modinvalid"
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        PkiKeyRing: managed object
+
+    Example:
+        key_ring = key_ring_create(handle, name="mykeyring")
+    """
+
+    from ucscsdk.mometa.pki.PkiKeyRing import PkiKeyRing
+
+    mo = PkiKeyRing(parent_mo_or_dn=ucsc_base_dn + "/pki-ext",
+                    name=name,
+                    descr=descr, tp=tp, cert=cert,
+                    regen=regen, modulus=modulus)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def key_ring_exists(handle, name, **kwargs):
+    """
+    Checks if a key ring exists
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        key_ring = key_ring_exists(handle, name="mykeyring")
+    """
+
+    dn = ucsc_base_dn + "/pki-ext/keyring-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def key_ring_modify(handle, name, **kwargs):
+    """
+    Modifies a key ring
+
+    Args:
+        handle (ucschandle)
+        name (string): name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        PkiKeyRing : Managed object
+
+    Raises:
+        ValueError: if PkiKeyRing is not present
+
+    Example:
+        key_ring = key_ring_modify(handle, name="mykeyring")
+    """
+
+    dn = ucsc_base_dn + "/pki-ext/keyring-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("keyring '%s' does not exist" % dn)
+
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def key_ring_delete(handle, name):
+    """
+    Deletes a key ring
+
+    Args:
+        handle (ucschandle)
+        name (string): name
+
+    Returns:
+        none
+
+    Raises:
+        ValueError: if pkikeyring mo is not present
+
+    Example:
+        key_ring_delete(handle, name="mykeyring")
+    """
+
+    dn = ucsc_base_dn + "/pki-ext/keyring-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("keyring '%s' does not exist" % dn)
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def certificate_request_add(handle, name, dns="", locality="", state="",
+                            country="", org_name="", org_unit_name="",
+                            email="", pwd="", subj_name="", ip="0.0.0.0",
+                            ip_a="0.0.0.0", ip_b="0.0.0.0", ipv6="::",
+                            ipv6_a="::", ipv6_b="::", **kwargs):
+    """
+    Adds a certificate request to keyring
+
+    Args:
+        handle (UcscHandle)
+        name (string): KeyRing name
+        dns (string): dns
+        locality (string): locality owner
+        state (string): state
+        country (string): country
+        org_name (string): org_name
+        org_unit_name (string): org_unit_name
+        email (string): email
+        pwd (string): pwd
+        subj_name (string): subj_name
+        ip (string): ipv4
+        ip_a (string):
+        ip_b (string):
+        ipv6 (string):
+        ipv6_a (string):
+        ipv6_b (string):
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        PkiCertReq: Managed object
+
+    Raises:
+        ValueError: If PkiKeyRing is not present
+
+    Example:
+        key_ring = key_ring_create(handle, name="mykeyring")
+
+        certificate_request_add(handle, key_ring=key_ring)
+    """
+
+    from ucscsdk.mometa.pki.PkiCertReq import PkiCertReq
+
+    dn = ucsc_base_dn + "/pki-ext/keyring-" + name
+    obj = handle.query_dn(dn)
+    if not obj:
+        raise ValueError("keyring '%s' does not exist" % dn)
+
+    mo = PkiCertReq(parent_mo_or_dn=obj,
+                    dns=dns,
+                    locality=locality,
+                    state=state,
+                    country=country,
+                    org_name=org_name,
+                    org_unit_name=org_unit_name,
+                    email=email,
+                    pwd=pwd,
+                    subj_name=subj_name,
+                    ip=ip,
+                    ip_a=ip_a,
+                    ip_b=ip_b,
+                    ipv6=ipv6,
+                    ipv6_a=ipv6_a,
+                    ipv6_b=ipv6_b)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def certificate_request_exists(handle, name, **kwargs):
+    """
+    Checks if a certificate request exists
+
+    Args:
+        handle (UcscHandle)
+        name (string): KeyRing name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        key_ring = key_ring_create(handle, name="mykeyring")
+
+        certificate_request_exists(handle, key_ring="keyring")
+    """
+
+    dn = ucsc_base_dn + "/pki-ext/keyring-" + name + "/certreq"
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+'''
+Note: certificate_request_modify is not possible
+'''
+
+
+def certificate_request_remove(handle, name):
+    """
+    Removes a certificate request from keyring
+
+    Args:
+        handle (UcscHandle)
+        name (string): KeyRing name
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If PkiCertReq is not present
+
+    Example:
+        key_ring = key_ring_create(handle, name="mykeyring")
+
+        certificate_request_remove(handle, key_ring=key_ring)
+
+    """
+
+    dn = ucsc_base_dn + "/pki-ext/keyring-" + name + "/certreq"
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("keyring certificate '%s' does not exist" % dn)
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def trusted_point_create(handle, name, descr="", cert_chain="", **kwargs):
+    """
+    Creates a trusted point
+
+    Args:
+        handle (ucschandle)
+        name (string): name
+        descr (string): description
+        cert_chain (string): chain of certificate
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        PkiTP: managed object
+
+    Example:
+        trusted_point = trusted_point_create(handle, name="mytrustedpoint")
+    """
+
+    from ucscsdk.mometa.pki.PkiTP import PkiTP
+
+    mo = PkiTP(parent_mo_or_dn=ucsc_base_dn + "/pki-ext",
+               name=name,
+               descr=descr,
+               cert_chain=cert_chain)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def trusted_point_exists(handle, name, **kwargs):
+    """
+    Checks if a trusted point exists
+
+    Args:
+        handle (ucschandle)
+        name (string): name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        key_ring = trusted_point_exists(handle, name="mytrustedpoint")
+    """
+
+    dn = ucsc_base_dn + "/pki-ext/tp-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def trusted_point_modify(handle, name, **kwargs):
+    """
+    Modifies a trusted point
+
+    Args:
+        handle (ucschandle)
+        name (string): name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        PkiTP object
+
+    Raises:
+        ValueError: if PkiTP not present
+
+    Example:
+        trusted_point = trusted_point_modify(handle, name="mytrustedpoin")
+    """
+
+    dn = ucsc_base_dn + "/pki-ext/tp-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("trusted point '%s' does not exist" % dn)
+
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def trusted_point_delete(handle, name):
+    """
+    Deletes a truted point
+
+    Args:
+        handle (ucschandle)
+        name (string): name
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: if PkiTP mo is not present
+
+    Example:
+        trusted_point_delete(handle, name="mytrustedpoint")
+    """
+
+    dn = ucsc_base_dn + "/pki-ext/tp-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("trust point '%s' does not exist" % dn)
+
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/admin/ldap.py
+++ b/ucsc_apis/admin/ldap.py
@@ -1,0 +1,639 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs the operation related to ldap.
+"""
+ucsc_base_dn = "org-root/deviceprofile-default"
+
+
+def ldap_provider_create(handle, name, order="lowest-available", rootdn="",
+                         basedn="", port="389", enable_ssl="no", filter="",
+                         attribute="", key="", timeout="30", vendor="OpenLdap",
+                         retries="1",  descr="", **kwargs):
+    """
+    creates a ldap provider
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of ldap provider
+        order (string): "lowest-available" or 0-16
+        rootdn (string): rootdn
+        basedn (string): basedn
+        port (string): port
+        enable_ssl (string): enable_ssl
+        filter (string): filter
+        attribute (string): attribute
+        key (string): key
+        timeout (string): timeout
+        vendor (string): vendor
+        retries (string): retries
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaLdapProvider : Managed Object
+
+    Example:
+        ldap_provider_create(handle, name="test_ldap_provider")
+    """
+
+    from ucscsdk.mometa.aaa.AaaLdapProvider import AaaLdapProvider
+
+    dn = ucsc_base_dn + "/ldap-ext"
+    ldap_mo = handle.query_dn(dn)
+    if not ldap_mo:
+        raise ValueError("LDAP MO doesn't exist")
+
+    mo = AaaLdapProvider(parent_mo_or_dn=dn,
+                         name=name,
+                         order=order,
+                         rootdn=rootdn,
+                         basedn=basedn,
+                         port=port,
+                         enable_ssl=enable_ssl,
+                         filter=filter,
+                         attribute=attribute,
+                         key=key,
+                         timeout=timeout,
+                         vendor=vendor,
+                         retries=retries,
+                         descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def ldap_provider_exists(handle, name, **kwargs):
+    """
+    checks if ldap provider exists
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of ldap provider
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        ldap_provider_exists(handle, name="test_ldap_provider")
+    """
+
+    dn = ucsc_base_dn + "/ldap-ext/provider-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def ldap_provider_modify(handle, name, **kwargs):
+    """
+    modifies a ldap provider
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of ldap provider
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        AaaLdapProvider : Managed Object
+
+    Raises:
+        ValueError: If AaaLdapProvider is not present
+
+    Example:
+        ldap_provider_modify(handle, name="test_ldap_provider")
+    """
+
+    dn = ucsc_base_dn + "/ldap-ext/provider-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Ldap Provider does not exist")
+
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def ldap_provider_delete(handle, name):
+    """
+    deletes a ldap provider
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of ldap provider
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaLdapProvider is not present
+
+    Example:
+        ldap_provider_delete(handle, name="test_ldap_provider")
+    """
+    dn = ucsc_base_dn + "/ldap-ext/provider-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Ldap Provider does not exist")
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def ldap_provider_configure_group_rules(handle, ldap_provider_name,
+                                        authorization=None, traversal=None,
+                                        target_attr=None, name=None,
+                                        descr=None, **kwargs):
+    """
+    configures group rules of a ldap provider
+
+    Args:
+        handle (UcscHandle)
+        ldap_provider_name (string): name of ldap provider
+        authorization (string): authorization
+        traversal (string): traversal
+        target_attr (string): target_attr
+        name (string): name
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaLdapGroupRule : Managed Object
+
+    Example:
+        ldap_provider_configure_group_rules(handle, name="test_ldap_provider")
+    """
+
+    from ucscsdk.mometa.aaa.AaaLdapGroupRule import AaaLdapGroupRule
+
+    dn = ucsc_base_dn + "/ldap-ext/provider-" + ldap_provider_name
+    obj = handle.query_dn(dn)
+    if not obj:
+        raise ValueError("Ldap Provider does not exist.")
+
+    mo = AaaLdapGroupRule(parent_mo_or_dn=obj)
+
+    if authorization:
+        mo.authorization = authorization
+    if traversal:
+        mo.traversal = traversal
+    if target_attr:
+        mo.target_attr = target_attr
+    if name:
+        mo.name = name
+    if descr:
+        mo.descr = descr
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def ldap_group_map_create(handle, name, descr="", **kwargs):
+    """
+    creates ldap group map
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaLdapGroup : Managed Object
+
+    Example:
+        ldap_group_map_create(handle, name="test_ldap_group_map")
+    """
+
+    from ucscsdk.mometa.aaa.AaaLdapGroup import AaaLdapGroup
+
+    mo = AaaLdapGroup(parent_mo_or_dn=ucsc_base_dn + "/ldap-ext",
+                      name=name, descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def ldap_group_map_exists(handle, name, **kwargs):
+    """
+    checks if ldap group map exists
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        ldap_group_map_exists(handle, name="test_ldap_group_map")
+    """
+
+    dn = ucsc_base_dn + "/ldap-ext/ldapgroup-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def ldap_group_map_delete(handle, name):
+    """
+    removes ldap group map
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaLdapGroup is not present
+
+    Example:
+        ldap_group_map_delete(handle, name="test_ldap_group_map")
+    """
+
+    dn = ucsc_base_dn + "/ldap-ext/ldapgroup-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Ldap Group does not exist")
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def ldap_group_map_add_role(handle, ldap_group_map_name, name, descr="",
+                            **kwargs):
+    """
+    add role to ldap group map
+
+    Args:
+        handle (UcscHandle)
+        ldap_group_map_name (string): name of ldap group
+        name (string):  role name
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaUserRole : Managed Object
+
+    Example:
+        ldap_group_map_add_role(handle,
+                                ldap_group_map_name="test_ldap_group_map",
+                                name="test_role")
+    """
+
+    from ucscsdk.mometa.aaa.AaaUserRole import AaaUserRole
+
+    dn = ucsc_base_dn + "/ldap-ext/ldapgroup-" + ldap_group_map_name
+    obj = handle.query_dn(dn)
+    if not obj:
+        raise ValueError("Ldap Group map '%s' does not exist" % dn)
+
+    mo = AaaUserRole(parent_mo_or_dn=obj, name=name, descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def ldap_group_map_role_exists(handle, ldap_group_map_name, name, **kwargs):
+    """
+    checks if role exists for the respective ldap group map
+
+    Args:
+        handle (UcscHandle)
+        ldap_group_map_name (string): name of ldap group
+        name (string):  role name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        ldap_group_map_role_exists(handle,
+                                ldap_group_map_name="test_ldap_group_map",
+                                name="test_role")
+    """
+
+    ldap_dn = ucsc_base_dn + "/ldap-ext/ldapgroup-" + ldap_group_map_name
+    dn = ldap_dn + "/role-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def ldap_group_map_remove_role(handle, ldap_group_map_name, name):
+    """
+    removes role from the respective ldap group map
+
+    Args:
+        handle (UcscHandle)
+        ldap_group_map_name (string): name of ldap group
+        name (string):  role name
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaUserRole is not present
+
+    Example:
+        ldap_group_map_remove_role(handle,
+                                ldap_group_map_name="test_ldap_group_map",
+                                name="test_role")
+    """
+
+    ldap_dn = ucsc_base_dn + "/ldap-ext/ldapgroup-" + ldap_group_map_name
+    dn = ldap_dn + "/role-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Ldap Group Role does not exist")
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def ldap_provider_group_create(handle, name, descr="", **kwargs):
+    """
+    creates ldap provider group
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaProviderGroup : Managed Object
+
+    Example:
+        ldap_provider_group_create(handle, name="test_ldap_group_map")
+    """
+
+    from ucscsdk.mometa.aaa.AaaProviderGroup import AaaProviderGroup
+
+    mo = AaaProviderGroup(parent_mo_or_dn=ucsc_base_dn + "/ldap-ext",
+                          name=name,
+                          descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def ldap_provider_group_exists(handle, name, **kwargs):
+    """
+    checks if ldap provider group exists
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        ldap_provider_group_exists(handle, name="test_ldap_group_map")
+    """
+
+    dn = ucsc_base_dn + "/ldap-ext/providergroup-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def ldap_provider_group_delete(handle, name):
+    """
+    deletes ldap provider group
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+        descr (string): descr
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaProviderGroup is not present
+
+    Example:
+        ldap_provider_group_delete(handle, name="test_ldap_group_map")
+    """
+
+    dn = ucsc_base_dn + "/ldap-ext/providergroup-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Provider  Group does not exist.")
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def ldap_provider_group_add_provider(handle, group_name, name,
+                                     order="lowest-available",
+                                     descr="", **kwargs):
+    """
+    adds provider to ldap provider group
+
+    Args:
+        handle (UcscHandle)
+        group_name (string): ldap provider group name
+        name (string): name
+        order (string): order
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaProviderRef : Managed Object
+
+    Raises:
+        ValueError: If AaaProviderGroup or AaaProvider is not present
+
+    Example:
+        ldap_provider_group_add_provider(handle,
+                                        group_name="test_ldap_provider_group",
+                                        name="test_provider",
+                                        order="1")
+    """
+
+    from ucscsdk.mometa.aaa.AaaProviderRef import AaaProviderRef
+
+    group_dn = ucsc_base_dn + "/ldap-ext/providergroup-" + group_name
+    group_mo = handle.query_dn(group_dn)
+    if not group_mo:
+        raise ValueError("Ldap Provider Group does not exist.")
+
+    provider_dn = ucsc_base_dn + "/ldap-ext/provider-" + name
+    provider_mo = handle.query_dn(provider_dn)
+    if not provider_mo:
+        raise ValueError("Ldap Provider does not exist.")
+
+    mo = AaaProviderRef(parent_mo_or_dn=group_mo,
+                        name=name,
+                        order=order,
+                        descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def ldap_provider_group_provider_exists(handle, group_name, name, **kwargs):
+    """
+    checks if provider added ldap provider group
+
+    Args:
+        handle (UcscHandle)
+        group_name (string): ldap provider group name
+        name (string): name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        ldap_provider_group_provider_exists(handle,
+                                        group_name="test_ldap_provider_group",
+                                        name="test_provider",
+                                        order="1")
+    """
+
+    group_dn = ucsc_base_dn + "/ldap-ext/providergroup-" + group_name
+    provider_dn = group_dn + "/provider-ref-" + name
+    mo = handle.query_dn(provider_dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def ldap_provider_group_modify_provider(handle, group_name, name, **kwargs):
+    """
+    modify provider of ldap provider group
+
+    Args:
+        handle (UcscHandle)
+        group_name (string): ldap provider group name
+        name (string): name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        True/False
+
+    Raises:
+        AaaProviderRef : Managed Object
+
+    Example:
+        ldap_provider_group_modify_provider(handle,
+                                        group_name="test_ldap_provider_group",
+                                        name="test_provider",
+                                        order="1")
+    """
+
+    group_dn = ucsc_base_dn + "/ldap-ext/providergroup-" + group_name
+    provider_dn = group_dn + "/provider-ref-" + name
+    mo = handle.query_dn(provider_dn)
+    if not mo:
+        raise ValueError("Provider not available under group.")
+
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def ldap_provider_group_remove_provider(handle, group_name, name):
+    """
+    removes provider from ldap provider group
+
+    Args:
+        handle (UcscHandle)
+        group_name (string): ldap provider group name
+        name (string): name
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaProviderRef is not present
+
+    Example:
+        ldap_provider_group_modify_provider(handle,
+                                        group_name="test_ldap_provider_group",
+                                        name="test_provider",
+                                        order="1")
+    """
+
+    group_dn = ucsc_base_dn + "/ldap-ext/providergroup-" + group_name
+    provider_dn = group_dn + "/provider-ref-" + name
+    provider_mo = handle.query_dn(provider_dn)
+    if not provider_mo:
+        raise ValueError("Provider not available under group.")
+
+    handle.remove_mo(provider_mo)
+    handle.commit()

--- a/ucsc_apis/admin/locale.py
+++ b/ucsc_apis/admin/locale.py
@@ -1,0 +1,279 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs the operation related to dns server management.
+"""
+ucsc_base_dn = "org-root/deviceprofile-default"
+
+
+def locale_create(handle, name, descr="", **kwargs):
+    """
+    creates a locale
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of ldap provider
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaLocale : Managed Object
+
+    Example:
+        locale_create(handle, name="test_locale")
+    """
+
+    from ucscsdk.mometa.aaa.AaaLocale import AaaLocale
+
+    mo = AaaLocale(parent_mo_or_dn=ucsc_base_dn,
+                   name=name,
+                   descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def locale_exists(handle, name, **kwargs):
+    """
+    checks if locale exists
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of ldap provider
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        locale_exists(handle, name="test_locale")
+    """
+
+    dn = ucsc_base_dn + "/locale-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def locale_modify(handle, name, **kwargs):
+    """
+    modifies a locale
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of locale
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        AaaLocale : Managed Object
+
+    Raises:
+        ValueError: If AaaLocale is not present
+
+    Example:
+        locale_modify(handle, name="test_locale")
+    """
+
+    dn = ucsc_base_dn + "/locale-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Locale does not exist")
+
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def locale_delete(handle, name):
+    """
+    deletes locale
+
+    Args:
+        handle (UcscHandle)
+        name (string): locale name
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaLocale is not present
+
+    Example:
+        locale_delete(handle, name="test_locale")
+    """
+
+    dn = ucsc_base_dn + "/locale-" + name
+    mo = handle.query_dn(dn)
+    if mo is None:
+        raise ValueError("Locale does not exist")
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def locale_assign_org(handle, locale_name, name, org_dn="org-root", descr="",
+                      **kwargs):
+    """
+    assigns a locale to org
+
+    Args:
+        handle (UcscHandle)
+        locale_name(string): locale name
+        name (string): name for the assignment
+        org_dn (string): org_dn
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaOrg : Managed Object
+
+    Raises:
+        ValueError: If AaaLocale is not present
+
+    Example:
+        locale_assign_org(handle, name="test_locale")
+    """
+
+    from ucscsdk.mometa.aaa.AaaOrg import AaaOrg
+
+    dn = ucsc_base_dn + "/locale-" + locale_name
+    obj = handle.query_dn(dn)
+    if not obj:
+        raise ValueError("Locale does not exist")
+
+    mo = AaaOrg(parent_mo_or_dn=obj, name=name, org_dn=org_dn, descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def locale_unassign_org(handle, locale_name, name):
+    """
+    unassigns a locale from org
+
+    Args:
+        handle (UcscHandle)
+        locale_name(string): locale name
+        name (string): name of assignment
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaOrg is not present
+
+    Example:
+        locale_unassign_org(handle, locale_name="test_locale,
+                            name="org_name")
+    """
+
+    locale_dn = ucsc_base_dn + "/locale-" + locale_name
+    dn = locale_dn + "/org-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("No Org assigned to Locale")
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def locale_assign_domaingroup(handle, locale_name, name,
+                              domaingroup_dn="domaingroup-root", descr="",
+                              **kwargs):
+    """
+    assigns a locale to domaingroup
+
+    Args:
+        handle (UcscHandle)
+        locale_name(string): locale name
+        name (string): name for the assignment
+        domaingroup_dn (string): domaingroup_dn
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaOrg : Managed Object
+
+    Raises:
+        ValueError: If AaaLocale is not present
+
+    Example:
+        locale_assign_domaingroup(handle, name="test_locale")
+    """
+
+    from ucscsdk.mometa.aaa.AaaDomainGroup import AaaDomainGroup
+
+    dn = ucsc_base_dn + "/locale-" + locale_name
+    obj = handle.query_dn(dn)
+    if not obj:
+        raise ValueError("Locale does not exist")
+
+    mo = AaaDomainGroup(parent_mo_or_dn=obj, name=name,
+                        domaingroup_dn=domaingroup_dn, descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def locale_unassign_domaingroup(handle, locale_name, name):
+    """
+    unassigns a locale
+
+    Args:
+        handle (UcscHandle)
+        locale_name(string): locale name
+        name (string): name of assignment
+        descr (string): descr
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaOrg is not present
+
+    Example:
+        locale_unassign_domaingroup(handle, locale_name="test_locale,
+                            name="domaingroup_name")
+    """
+
+    locale_dn = ucsc_base_dn + "/locale-" + locale_name
+    dn = locale_dn + "/domaingroup-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("No domaingroup assigned to Locale")
+
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/admin/radius.py
+++ b/ucsc_apis/admin/radius.py
@@ -1,0 +1,390 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs the operation related to radius configuration.
+"""
+ucsc_base_dn = "org-root/deviceprofile-default"
+
+
+def radius_provider_create(handle, name, order="lowest-available", key="",
+                           auth_port="1812", timeout="5", retries="1",
+                           enc_key="", descr="", **kwargs):
+    """
+    Creates a radius provider
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+        order (string): order
+        key (string): key
+        auth_port (string): auth_port
+        timeout (string): timeout
+        retries (string): retries
+        enc_key (string): enc_key
+        descr (string): description
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaRadiusProvider: Managed Object
+
+    Example:
+        radius_provider_create(handle, name="test_radius_provider")
+    """
+
+    from ucscsdk.mometa.aaa.AaaRadiusProvider import AaaRadiusProvider
+
+    mo = AaaRadiusProvider(
+        parent_mo_or_dn=ucsc_base_dn + "/radius-ext",
+        name=name,
+        order=order,
+        key=key,
+        auth_port=auth_port,
+        timeout=timeout,
+        retries=retries,
+        enc_key=enc_key,
+        descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def radius_provider_exists(handle, name, **kwargs):
+    """
+    checks if radius provider exists
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        radius_provider_exists(handle, name="test_radius_provider")
+    """
+
+    dn = ucsc_base_dn + "/radius-ext/provider-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def radius_provider_modify(handle, name, **kwargs):
+    """
+    modifies a radius provider
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        AaaRadiusProvider: Managed Object
+
+    Raises:
+        ValueError: If AaaRadiusProvider is not present
+
+    Example:
+        radius_provider_modify(handle, name="test_radius_provider")
+    """
+
+    dn = ucsc_base_dn + "/radius-ext/provider-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Radius Provider does not exist %s" % dn)
+
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def radius_provider_delete(handle, name):
+    """
+    deletes a radius provider
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaRadiusProvider is not present
+
+    Example:
+        radius_provider_delete(handle, name="test_radius_provider")
+    """
+
+    dn = ucsc_base_dn + "/radius-ext/provider-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Radius Provider does not exist")
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def radius_provider_group_create(handle, name, descr="", **kwargs):
+    """
+    Creates a radius provider group
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+        descr (string): description
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaProviderGroup: Managed Object
+
+    Example:
+        radius_provider_group_create(handle, name="test_radius_provider_group")
+    """
+
+    from ucscsdk.mometa.aaa.AaaProviderGroup import AaaProviderGroup
+
+    mo = AaaProviderGroup(
+        parent_mo_or_dn=ucsc_base_dn + "/radius-ext",
+        name=name, descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def radius_provider_group_exists(handle, name, **kwargs):
+    """
+    checks if radius provider group exists
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        radius_provider_group_exists(handle, name="test_radius_provider_group")
+    """
+
+    dn = ucsc_base_dn + "/radius-ext/providergroup-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def radius_provider_group_delete(handle, name):
+    """
+    deletes a radius provider group
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaProviderGroup is not present
+
+    Example:
+        radius_provider_group_delete(handle, name="test_radius_provider_group")
+    """
+
+    dn = ucsc_base_dn + "/radius-ext/providergroup-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Provider  Group does not exist.")
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def radius_provider_group_add_provider(handle, group_name, name,
+                                       order="lowest-available", descr="",
+                                       **kwargs):
+    """
+    adds a provider to a radius provider group
+
+    Args:
+        handle (UcscHandle)
+        group_name (string): group_name
+        name (string): name
+        order (string): order
+        descr (string): description
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaProviderRef: Managed Object
+
+    Raises:
+        ValueError: If AaaProviderGroup  or AaaProvider is not present
+
+    Example:
+        radius_provider_group_add_provider(handle,
+                                    group_name="test_radius_provider_group",
+                                    name="test_radius_provider")
+    """
+
+    from ucscsdk.mometa.aaa.AaaProviderRef import AaaProviderRef
+
+    group_dn = ucsc_base_dn + "/radius-ext/providergroup-" + group_name
+    group_mo = handle.query_dn(group_dn)
+    if not group_mo:
+        raise ValueError("Radius Provider Group does not exist.")
+
+    provider_dn = ucsc_base_dn + "/radius-ext/provider-" + name
+    mo = handle.query_dn(provider_dn)
+    if not mo:
+        raise ValueError("Radius Provider does not exist.")
+
+    mo = AaaProviderRef(parent_mo_or_dn=group_mo,
+                        name=name,
+                        order=order,
+                        descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def radius_provider_group_provider_exists(handle, group_name, name, **kwargs):
+    """
+    checks if a provider exists under a radius provider group
+
+    Args:
+        handle (UcscHandle)
+        group_name (string): group_name
+        name (string): name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Raises:
+        ValueError: If AaaProviderGroup  or AaaProvider is not present
+
+    Example:
+        radius_provider_group_provider_exists(handle,
+                                    group_name="test_radius_provider_group",
+                                    name="test_radius_provider")
+    """
+
+    group_dn = ucsc_base_dn + "/radius-ext/providergroup-" + group_name
+    group_mo = handle.query_dn(group_dn)
+    if not group_mo:
+        raise ValueError("Radius Provider Group does not exist.")
+
+    provider_dn = group_dn + "/provider-ref-" + name
+    mo = handle.query_dn(provider_dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def radius_provider_group_modify_provider(handle, group_name, name, **kwargs):
+    """
+    modifies a provider to a radius provider group
+
+    Args:
+        handle (UcscHandle)
+        group_name (string): group_name
+        name (string): name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        AaaProviderRef: Managed Object
+
+    Raises:
+        ValueError: If AaaProviderRef is not present
+
+    Example:
+        radius_provider_group_modify_provider(handle,
+                                    group_name="test_radius_provider_group",
+                                    name="test_radius_provider")
+    """
+
+    group_dn = ucsc_base_dn + "/radius-ext/providergroup-" + group_name
+    provider_dn = group_dn + "/provider-ref-" + name
+    mo = handle.query_dn(provider_dn)
+    if not mo:
+        raise ValueError("Provider not available under group.")
+
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def radius_provider_group_remove_provider(handle, group_name, name):
+    """
+    removes a provider from a radius provider group
+
+    Args:
+        handle (UcscHandle)
+        group_name (string): group_name
+        name (string): name
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaProviderRef is not present
+
+    Example:
+        radius_provider_group_remove_provider(handle,
+                                    group_name="test_radius_provider_group",
+                                    name="test_radius_provider")
+    """
+
+    group_dn = ucsc_base_dn + "/radius-ext/providergroup-" + group_name
+    provider_dn = group_dn + "/provider-ref-" + name
+    mo = handle.query_dn(provider_dn)
+    if not mo:
+        raise ValueError("Provider not available under group.")
+
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/admin/role.py
+++ b/ucsc_apis/admin/role.py
@@ -1,0 +1,137 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs the operation related to role.
+"""
+ucsc_base_dn = "org-root/deviceprofile-default"
+
+
+def role_create(handle, name, priv, descr="", **kwargs):
+    """
+    creates a role
+
+    Args:
+        handle (UcscHandle)
+        name (string): role name
+        priv (comma separated string): role privilege
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaRole: Managed Object
+
+    Example:
+        role_create(handle, name="testrole", priv="read-only")
+
+    """
+
+    from ucscsdk.mometa.aaa.AaaRole import AaaRole
+
+    mo = AaaRole(parent_mo_or_dn=ucsc_base_dn,
+                 name=name,
+                 priv=priv,
+                 descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def role_exists(handle, name, **kwargs):
+    """
+    checks if a role exists
+
+    Args:
+        handle (UcscHandle)
+        name (string): role name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        role_exists(handle, name="testrole", priv="read-only")
+    """
+
+    dn = ucsc_base_dn + "/role-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def role_modify(handle, name, **kwargs):
+    """
+    modifies role
+
+    Args:
+        handle (UcscHandle)
+        name (string): role name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        AaaRole: Managed Object
+
+    Raises:
+        ValueError: If AaaRole is not present
+
+    Example:
+        role_modify(handle, name="testrole", priv="read-only")
+    """
+
+    dn = ucsc_base_dn + "/role-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Role does not exist")
+
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def role_delete(handle, name):
+    """
+    deletes role
+
+    Args:
+        handle (UcscHandle)
+        name (string): role name
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaRole is not present
+
+    Example:
+        role_delete(handle, name="testrole")
+    """
+
+    dn = ucsc_base_dn + "/role-" + name
+    mo = handle.query_dn(dn)
+    if mo is None:
+        raise ValueError("Role does not exist")
+
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/admin/snmp.py
+++ b/ucsc_apis/admin/snmp.py
@@ -1,0 +1,379 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs the operation related to snmp server, user and traps.
+"""
+ucsc_base_dn = "org-root/deviceprofile-default"
+
+
+def snmp_enable(handle, community=None, sys_contact=None, sys_location=None,
+                descr=None, **kwargs):
+    """
+    Enables SNMP.
+
+    Args:
+        handle (UcscHandle)
+        community (string): community
+        sys_contact (string): sys_contact
+        sys_location (string): sys_location
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        CommSnmp: Managed object
+
+    Raises:
+        ValueError: If CommSnmp Mo is not present
+
+    Example:
+        mo = snmp_enable(handle,
+                    community="username",
+                    sys_contact="user contact",
+                    sys_location="user location",
+                    descr="SNMP Service")
+
+    """
+
+    from ucscsdk.mometa.comm.CommSnmp import CommSnmpConsts
+
+    dn = ucsc_base_dn + "/snmp-svc"
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("snmp config '%s' does not exist" % dn)
+
+    mo.admin_state = CommSnmpConsts.ADMIN_STATE_ENABLED
+
+    if community is not None:
+        mo.community = community
+    if sys_contact is not None:
+        mo.sys_contact = sys_contact
+    if sys_location is not None:
+        mo.sys_location = sys_location
+    if descr is not None:
+        mo.descr = descr
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def snmp_disable(handle):
+    """
+    Disables SNMP.
+
+    Args:
+        handle (UcscHandle)
+
+    Returns:
+        CommSnmp: Managed Object
+
+    Raises:
+        ValueError: If CommSnmp Mo is not present
+
+    Example:
+        snmp_disable(handle)
+    """
+
+    from ucscsdk.mometa.comm.CommSnmp import CommSnmpConsts
+
+    dn = ucsc_base_dn + "/snmp-svc"
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("snmp config '%s' does not exist" % dn)
+
+    mo.admin_state = CommSnmpConsts.ADMIN_STATE_DISABLED
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def snmp_trap_add(handle, hostname, community, port="162", version="v2c",
+                  notification_type="traps", v3_privilege="noauth", **kwargs):
+    """
+    Adds snmp trap.
+
+    Args:
+        handle (UcscHandle)
+        hostname (string): ip address
+        community (string): community
+        port (number): port
+        version (string): "v1", "v2c", "v3"
+        notification_type (string): "informs", "traps"
+            Required only for version "v2c" and "v3"
+        v3_privilege (string): "auth", "noauth", "priv"
+            Required only for version "v3"
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        CommSnmpTrap: Managed Object
+
+    Example:
+        snmp_trap_add(handle, hostname="10.10.10.10",
+                      community="username", port="162",
+                      version="v2c",
+                      notification_type="informs")
+
+    """
+
+    from ucscsdk.mometa.comm.CommSnmpTrap import CommSnmpTrap
+    mo = CommSnmpTrap(
+        parent_mo_or_dn=ucsc_base_dn + "/snmp-svc",
+        hostname=hostname,
+        community=community,
+        port=port,
+        version=version,
+        notification_type=notification_type,
+        v3_privilege=v3_privilege)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def snmp_trap_exists(handle, hostname, **kwargs):
+    """
+    checks if snmp trap exists
+
+    Args:
+        handle (UcscHandle)
+        hostname (string): ip address
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        snmp_trap_exists(handle, hostname="10.10.10.10",
+                      community="username", port="162",
+                      version="v2c",
+                      notification_type="informs")
+
+    """
+
+    dn = ucsc_base_dn + "/snmp-svc/snmp-trap" + hostname
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def snmp_trap_modify(handle, hostname, **kwargs):
+    """
+    Modifies snmp trap.
+
+    Args:
+        handle (UcscHandle)
+        hostname (string): ip address
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        CommSnmpTrap: Managed Object
+
+    Raises:
+        ValueError: If CommSnmpTrap Mo is not present
+
+    Example:
+        snmp_trap_modify(handle, hostname="10.10.10.10",
+                          community="username", port="162",
+                          version="v3",
+                          notification_type="traps",
+                          v3_privilege="noauth")
+
+    """
+
+    dn = ucsc_base_dn + "/snmp-svc/snmp-trap" + hostname
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("snmp trap MO is not available")
+
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def snmp_trap_remove(handle, hostname):
+    """
+    Modifies snmp trap.
+
+    Args:
+        handle (UcscHandle)
+        hostname (string): ip address
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If CommSnmpTrap Mo is not present
+
+    Example:
+        snmp_trap_remove(handle, hostname="10.10.10.10")
+
+    """
+
+    dn = ucsc_base_dn + "/snmp-svc/snmp-trap" + hostname
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("snmp trap MO is not available")
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def snmp_user_add(handle, name, pwd, privpwd, auth="md5",
+                  use_aes="no", descr="", **kwargs):
+    """
+    Adds snmp user.
+
+    Args:
+        handle (UcscHandle)
+        name (string): snmp username
+        descr (string): description
+        pwd (string): password
+        privpwd (string): privacy password
+        auth (string): "md5", "sha"
+        use_aes (string): "yes", "no"
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        CommSnmpUser: Managed Object
+
+    Example:
+        snmp_user_add(handle, name="snmpuser", descr="", pwd="password",
+                    privpwd="password", auth="sha")
+
+    """
+
+    from ucscsdk.mometa.comm.CommSnmpUser import CommSnmpUser
+
+    mo = CommSnmpUser(
+        parent_mo_or_dn=ucsc_base_dn + "/snmp-svc",
+        name=name,
+        descr=descr,
+        pwd=pwd,
+        privpwd=privpwd,
+        auth=auth,
+        use_aes=use_aes)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def snmp_user_exists(handle, name, **kwargs):
+    """
+    checks if snmp user exists.
+
+    Args:
+        handle (UcscHandle)
+        name (string): snmp username
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        snmp_user_exists(handle, name="snmpuser", descr="",
+                    auth="sha")
+
+    """
+
+    dn = ucsc_base_dn + "/snmp-svc/snmpv3-user-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def snmp_user_modify(handle, name, **kwargs):
+    """
+    Modifies snmp user.
+
+    Args:
+        handle (UcscHandle)
+        name (string): snmp username
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        CommSnmpUser: Managed Object
+
+    Raises:
+        ValueError: If CommSnmpUser Mo is not present
+
+    Example:
+        snmp_user_modify(handle, name="snmpuser", descr="",
+                          pwd="password", privpwd="password",
+                          auth="md5", use_aes="no")
+
+    """
+
+    dn = ucsc_base_dn + "/snmp-svc/snmpv3-user-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("snmp user MO is not available")
+
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def snmp_user_remove(handle, name):
+    """
+    removes snmp user.
+
+    Args:
+        handle (UcscHandle)
+        name (string): snmp username
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If CommSnmpUser Mo is not present
+
+    Example:
+        snmp_user_remove(handle, name="snmpuser")
+
+    """
+
+    dn = ucsc_base_dn + "/snmp-svc/snmpv3-user-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("snmp user MO is not available")
+
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/admin/syslog.py
+++ b/ucsc_apis/admin/syslog.py
@@ -1,0 +1,363 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This module performs the operation related to syslog.
+"""
+ucsc_base_dn = "org-root/deviceprofile-default"
+
+
+def syslog_local_console_enable(handle, severity="emergencies", **kwargs):
+    """
+    This method enables system logs on local console.
+
+    Args:
+        handle (UcscHandle)
+        severity (string): Level of logging.
+                           ["alerts", "critical", "emergencies"]
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        CommSyslogConsole: Managed Object
+
+    Raises:
+        ValueError: If CommSyslogConsole is not present
+
+    Example:
+        syslog_local_console_enable(handle, severity="alert")
+    """
+
+    from ucscsdk.mometa.comm.CommSyslogConsole import \
+        CommSyslogConsoleConsts
+
+    dn = ucsc_base_dn + "/syslog/console"
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("sys log console does not exist.")
+
+    mo.admin_state = CommSyslogConsoleConsts.ADMIN_STATE_ENABLED
+    mo.severity = severity
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def syslog_local_console_disable(handle):
+    """
+    This method disables system logs on local console.
+
+    Args:
+        handle (UcscHandle)
+
+    Returns:
+        CommSyslogConsole: Managed Object
+
+    Raises:
+        ValueError: If CommSyslogConsole is not present
+
+    Example:
+        syslog_local_console_enable(handle)
+    """
+
+    from ucscsdk.mometa.comm.CommSyslogConsole import \
+        CommSyslogConsoleConsts
+
+    dn = ucsc_base_dn + "/syslog/console"
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("sys log console does not exist.")
+
+    mo.admin_state = CommSyslogConsoleConsts.ADMIN_STATE_DISABLED
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def syslog_local_monitor_enable(handle, severity="emergencies", **kwargs):
+    """
+    This method enables logs on local monitor.
+
+    Args:
+        handle (UcscHandle)
+        severity (string): Level of logging.
+                        ["alerts", "critical", "debugging", "emergencies",
+                        "errors", "information", "notifications", "warnings"]
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        CommSyslogMonitor: Managed Object
+
+    Raises:
+        ValueError: If CommSyslogMonitor is not present
+
+    Example:
+        syslog_local_monitor_enable(handle, severity="alert")
+    """
+
+    from ucscsdk.mometa.comm.CommSyslogMonitor import \
+        CommSyslogMonitorConsts
+
+    dn = ucsc_base_dn + "/syslog/monitor"
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("sys log monitor does not exist.")
+
+    mo.admin_state = CommSyslogMonitorConsts.ADMIN_STATE_ENABLED
+    mo.severity = severity
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def syslog_local_monitor_disable(handle):
+    """
+    This method disables logs on local monitor.
+
+    Args:
+        handle (UcscHandle)
+
+    Returns:
+        CommSyslogMonitor: Managed Object
+
+    Raises:
+        ValueError: If CommSyslogMonitor is not present
+
+    Example:
+        mo = syslog_local_monitor_disable(handle)
+    """
+
+    from ucscsdk.mometa.comm.CommSyslogMonitor import \
+        CommSyslogMonitorConsts
+
+    dn = ucsc_base_dn + "/syslog/monitor"
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("sys log monitor does not exist.")
+
+    mo.admin_state = CommSyslogMonitorConsts.ADMIN_STATE_DISABLED
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def syslog_local_file_enable(handle, name="", severity="emergencies",
+                             size="40000", **kwargs):
+    """
+    This method configures System Logs on local file storage.
+
+    Args:
+        handle (UcscHandle)
+        name (string): Name of Log file.
+        severity (string): Level of logging.
+        size (string): Maximum allowed size of log file(In KBs).
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        CommSyslogFile: Managed object
+
+    Raises:
+        ValueError: If CommSyslogFile is not present
+
+    Example:
+        syslog_local_file_enable(handle, severity="alert", size="435675",
+                                name="sys_log")
+    """
+
+    from ucscsdk.mometa.comm.CommSyslogFile import CommSyslogFileConsts
+
+    dn = ucsc_base_dn + "/syslog/file"
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("sys log file does not exist.")
+
+    mo.admin_state = CommSyslogFileConsts.ADMIN_STATE_ENABLED
+    mo.name = name
+    mo.severity = severity
+    mo.size = size
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def syslog_local_file_disable(handle):
+    """
+    This method disables System Logs on local file storage.
+
+    Args:
+        handle (UcscHandle)
+
+    Returns:
+        CommSyslogFile: Managed Object
+
+    Raises:
+        ValueError: If CommSyslogFile is not present
+
+    Example:
+        syslog_local_file_disable(handle)
+    """
+
+    from ucscsdk.mometa.comm.CommSyslogFile import CommSyslogFileConsts
+
+    dn = ucsc_base_dn + "/syslog/file"
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("sys log file does not exist.")
+
+    mo.admin_state = CommSyslogFileConsts.ADMIN_STATE_DISABLED
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def syslog_remote_enable(handle, name, hostname="none",
+                         severity="emergencies", forwarding_facility="local0",
+                         **kwargs):
+    """
+    This method enables System Logs on remote server.
+
+    Args:
+        handle (UcscHandle)
+        name (string): Remote Server ID -
+                            "primary" or "secondary" or "tertiary"
+        hostname (string) : Remote host IP or Name
+        severity (string): Level of logging.
+                        ["alerts", "critical", "debugging", "emergencies",
+                        "errors", "information", "notifications", "warnings"]
+
+        forwarding_facility (string): Forwarding mechanism local0 to local7.
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        CommSyslogClient Object
+
+    Raises:
+        ValueError: If CommSyslogClient is not present
+
+    Example:
+        syslog_remote_enable(handle, name="primary", hostname="192.168.1.2",
+                    severity="alert")
+    """
+
+    from ucscsdk.mometa.comm.CommSyslogClient import \
+        CommSyslogClientConsts
+
+    dn = ucsc_base_dn + "/syslog/client-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Remote Destination '%s' does not exist" % dn)
+
+    mo.admin_state = CommSyslogClientConsts.ADMIN_STATE_ENABLED
+    mo.forwarding_facility = forwarding_facility
+    mo.hostname = hostname
+    mo.severity = severity
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def syslog_remote_disable(handle, name):
+    """
+    This method enables System Logs on remote server.
+
+    Args:
+        handle (UcscHandle)
+        name (string): Remote Server ID -
+                            "primary" or "secondary" or "tertiary"
+
+    Returns:
+        CommSyslogClient: Managed Object
+
+    Raises:
+        ValueError: If CommSyslogClient is not present
+
+    Example:
+        syslog_remote_disable(handle, name="primary")
+    """
+
+    from ucscsdk.mometa.comm.CommSyslogClient import \
+        CommSyslogClientConsts
+
+    dn = ucsc_base_dn + "/syslog/client-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Remote Destination '%s' does not exist" % dn)
+
+    mo.admin_state = CommSyslogClientConsts.ADMIN_STATE_DISABLED
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def syslog_source(handle, faults=None, audits=None, events=None, **kwargs):
+    """
+    This method configures Type of System Logs.
+
+    Args:
+        handle (UcscHandle)
+        faults (string) : for fault logging. ["disabled", "enabled"]
+        audits (string): for audit task logging. ["disabled", "enabled"]
+        events (string): for event logging. ["disabled", "enabled"]
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        CommSyslogSource: Managed object
+
+    Raises:
+        ValueError: If CommSyslogSource is not present
+
+    Example:
+            syslog_source(handle, faults="enabled", audits="disabled",
+                    events="disabled")
+
+    """
+
+    dn = ucsc_base_dn + "/syslog/source"
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("local sources '%s' does not exist" % dn)
+
+    if faults is not None:
+        mo.faults = faults
+    if audits is not None:
+        mo.audits = audits
+    if events is not None:
+        mo.events = events
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo

--- a/ucsc_apis/admin/tacacsplus.py
+++ b/ucsc_apis/admin/tacacsplus.py
@@ -1,0 +1,392 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs the operation related to dns server management.
+"""
+ucsc_base_dn = "org-root/deviceprofile-default"
+
+
+def tacacsplus_provider_create(handle, name, order="lowest-available", key="",
+                               port="49", timeout="5", retries="1", enc_key="",
+                               descr="", **kwargs):
+    """
+    Creates a tacacsplus provider
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of tacacsplus provider
+        order (string): order
+        key (string): key
+        port (string): port
+        timeout (string): timeout
+        retries (string): retries
+        enc_key (string): enc_key
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaTacacsPlusProvider: Managed Object
+
+    Example:
+        tacacsplus_provider_create(handle, name="tacacsplus_provider")
+    """
+
+    from ucscsdk.mometa.aaa.AaaTacacsPlusProvider import \
+        AaaTacacsPlusProvider
+
+    mo = AaaTacacsPlusProvider(
+        parent_mo_or_dn=ucsc_base_dn + "/tacacs-ext",
+        name=name,
+        order=order,
+        key=key,
+        port=port,
+        timeout=timeout,
+        retries=retries,
+        enc_key=enc_key,
+        descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def tacacsplus_provider_exists(handle, name, **kwargs):
+    """
+    checks if a tacacsplus provider exists
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of tacacsplus provider
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        tacacsplus_provider_exists(handle, name="tacacsplus_provider")
+    """
+
+    dn = ucsc_base_dn + "/tacacs-ext/provider-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def tacacsplus_provider_modify(handle, name, **kwargs):
+    """
+    modifies a tacacsplus provider
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of tacacsplus provider
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        AaaTacacsPlusProvider: Managed Object
+
+    Raises:
+        ValueError: If AaaTacacsPlusProvider is not present
+
+    Example:
+        tacacsplus_provider_modify(handle, name="tacacsplus_provider")
+    """
+
+    dn = ucsc_base_dn + "/tacacs-ext/provider-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("TacacsPlus Provider '%s' does not exist" % dn)
+
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def tacacsplus_provider_delete(handle, name):
+    """
+    deletes a tacacsplus provider
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of tacacsplus provider
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaTacacsPlusProvider is not present
+
+    Example:
+        tacacsplus_provider_delete(handle, name="tacacsplus_provider")
+    """
+
+    dn = ucsc_base_dn + "/tacacs-ext/provider-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("TacacsPlus Provider does not exist")
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def tacacsplus_provider_group_create(handle, name, descr="", **kwargs):
+    """
+    Creates a tacacsplus provider group
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of tacacsplus provider group
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaTacacsPlusProvider: Managed Object
+
+    Example:
+        tacacsplus_provider_create(handle, name="tacacsplus_provider")
+    """
+
+    from ucscsdk.mometa.aaa.AaaProviderGroup import AaaProviderGroup
+
+    mo = AaaProviderGroup(
+        parent_mo_or_dn=ucsc_base_dn + "/tacacs-ext",
+        name=name, descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def tacacsplus_provider_group_exists(handle, name, **kwargs):
+    """
+    checks if a tacacsplus provider group exists
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of tacacsplus provider group
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        tacacsplus_provider_group_exists(handle, name="tacacsplus_provider")
+    """
+
+    dn = ucsc_base_dn + "/tacacs-ext/providergroup-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def tacacsplus_provider_group_delete(handle, name):
+    """
+    deletes a tacacsplus provider group
+
+    Args:
+        handle (UcscHandle)
+        name (string): name of tacacsplus provider group
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaProviderGroup is not present
+
+    Example:
+        tacacsplus_provider_group_delete(handle, name="tacacsplus_provider")
+    """
+
+    dn = ucsc_base_dn + "/tacacs-ext/providergroup-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Provider  Group does not exist.")
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def tacacsplus_provider_group_add_provider(handle, group_name, name,
+                                           order="lowest-available",
+                                           descr="", **kwargs):
+    """
+    adds a tacacsplus provider to a tacacsplus provider  group
+
+    Args:
+        handle (UcscHandle)
+        group_name (string): name of tacacsplus provider group
+        order (string): order
+        name (string): name of tacacsplus provider
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaProviderRef: Managed Object
+
+    Raises:
+        ValueError: If AaaProviderGroup Or AaaProvider is not present
+
+    Example:
+        tacacsplus_provider_group_add_provider(handle,
+                                    group_name="tacacsplus_provider_group",
+                                    name="tacacsplus_provider")
+    """
+
+    from ucscsdk.mometa.aaa.AaaProviderRef import AaaProviderRef
+
+    group_dn = ucsc_base_dn + "/tacacs-ext/providergroup-" + group_name
+    group_mo = handle.query_dn(group_dn)
+    if not group_mo:
+        raise ValueError("TacacsPlus Provider Group does not exist.")
+
+    provider_dn = ucsc_base_dn + "/tacacs-ext/provider-" + name
+    mo = handle.query_dn(provider_dn)
+    if not mo:
+        raise ValueError("TacacsPlus Provider does not exist.")
+
+    mo = AaaProviderRef(parent_mo_or_dn=group_mo,
+                        name=name,
+                        order=order,
+                        descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def tacacsplus_provider_group_provider_exists(handle, group_name, name,
+                                              **kwargs):
+    """
+    checks if a tacacsplus provider added to a tacacsplus provider  group
+
+    Args:
+        handle (UcscHandle)
+        group_name (string): name of tacacsplus provider group
+        name (string): name of tacacsplus provider
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Raises:
+        ValueError: If AaaProviderGroup is not present
+
+    Example:
+        tacacsplus_provider_group_add_provider(handle,
+                                    group_name="tacacsplus_provider_group",
+                                    name="tacacsplus_provider")
+    """
+
+    group_dn = ucsc_base_dn + "/tacacs-ext/providergroup-" + group_name
+    group_mo = handle.query_dn(group_dn)
+    if not group_mo:
+        raise ValueError("TacacsPlus Provider Group does not exist.")
+
+    provider_dn = group_dn + "/provider-ref-" + name
+    mo = handle.query_dn(provider_dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def tacacsplus_provider_group_modify_provider(handle, group_name, name,
+                                              **kwargs):
+    """
+    modifies a tacacsplus provider added to a tacacsplus provider  group
+
+    Args:
+        handle (UcscHandle)
+        group_name (string): name of tacacsplus provider group
+        name (string): name of tacacsplus provider
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        AaaProviderRef: Managed Object
+
+    Raises:
+        ValueError: If AaaProviderRef is not present
+
+    Example:
+        tacacsplus_provider_group_add_provider(handle,
+                                    group_name="tacacsplus_provider_group",
+                                    name="tacacsplus_provider")
+    """
+
+    group_dn = ucsc_base_dn + "/tacacs-ext/providergroup-" + group_name
+    provider_dn = group_dn + "/provider-ref-" + name
+    mo = handle.query_dn(provider_dn)
+    if not mo:
+        raise ValueError("Provider not available under group.")
+
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def tacacsplus_provider_group_remove_provider(handle, group_name, name):
+    """
+    removes a tacacsplus provider from a tacacsplus provider  group
+
+    Args:
+        handle (UcscHandle)
+        group_name (string): name of tacacsplus provider group
+        name (string): name of tacacsplus provider
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaProviderRef is not present
+
+    Example:
+        tacacsplus_provider_group_remove_provider(handle,
+                                    group_name="tacacsplus_provider_group",
+                                    name="tacacsplus_provider")
+    """
+
+    group_dn = ucsc_base_dn + "/tacacs-ext/providergroup-" + group_name
+    provider_dn = group_dn + "/provider-ref-" + name
+    mo = handle.query_dn(provider_dn)
+    if not mo:
+        raise ValueError("Provider not available under group.")
+
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/admin/timezone.py
+++ b/ucsc_apis/admin/timezone.py
@@ -1,0 +1,139 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+ucsc_base_dn = "org-root/deviceprofile-default"
+
+
+def time_zone_set(handle, timezone, **kwargs):
+    """
+    This method sets the timezone of the UCS Central.
+
+    Args:
+        handle (UcscHandle)
+        timezone (string): time zone e.g. "Asia/Kolkata"
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        CommDateTime: Managed object
+
+    Raises:
+        ValueError: If CommDateTime Mo is not found
+
+    Example:
+        To Set Time Zone:
+            mo = time_zone_set(handle, "Asia/Kolkata")
+
+        To Un-Set Time Zone:
+            mo = time_zone_set(handle, "")
+    """
+
+    mo = handle.query_dn(ucsc_base_dn + "/datetime-svc")
+    if not mo:
+        raise ValueError("timezone does not exist")
+
+    mo.timezone = timezone
+    mo.admin_state = "enabled"
+    mo.port = "0"
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def ntp_server_create(handle, name, descr="", **kwargs):
+    """
+    Adds NTP server using IP address.
+
+    Args:
+        handle (UcscHandle)
+        name (string): NTP server IP address or Name
+        descr (string): Basic description about NTP server
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        CommNtpProvider: Managed object
+
+    Example:
+        ntp_server_create(handle, "72.163.128.140", "Default NTP")
+    """
+
+    from ucscsdk.mometa.comm.CommNtpProvider import CommNtpProvider
+
+    mo = CommNtpProvider(
+        parent_mo_or_dn=ucsc_base_dn + "/datetime-svc",
+        name=name,
+        descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def ntp_server_exists(handle, name, **kwargs):
+    """
+    checks if ntp server exists.
+
+    Args:
+        handle (UcscHandle)
+        name (string): NTP server IP address or Name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        ntp_server_exists(handle, "72.163.128.140", descr="Default NTP")
+    """
+
+    dn = ucsc_base_dn + "/datetime-svc/ntp-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def ntp_server_remove(handle, name):
+    """
+    Removes the NTP server.
+
+    Args:
+        handle (UcscHandle)
+        name : NTP server IP address or Name
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If CommNtpProvider is not found
+
+    Example:
+        ntp_server_remove(handle, "72.163.128.140")
+    """
+
+    dn = ucsc_base_dn + "/datetime-svc/ntp-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("NTP Server not found. Nothing to remove.")
+
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/admin/user.py
+++ b/ucsc_apis/admin/user.py
@@ -1,0 +1,483 @@
+# Copyright 2015 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs the operation related to user.
+"""
+ucsc_base_dn = "org-root/deviceprofile-default"
+
+
+def user_create(handle, name, pwd, first_name="", last_name="", descr="",
+                clear_pwd_history="no", phone="", email="", expires="no",
+                pwd_life_time="no-password-expire", expiration="never",
+                enc_pwd="", account_status="active",
+                role="read-only", role_descr="", **kwargs):
+    """
+    Creates user and assign role to it.
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+        first_name (string): first_name
+        last_name (string): last_name
+        descr (string): descr
+        clear_pwd_history (string): clear_pwd_history
+        phone (string): phone
+        email (string): email
+        pwd (string): pwd
+        expires (string): expires
+        pwd_life_time (string): pwd_life_time
+        expiration (string): expiration
+        enc_pwd (string): enc_pwd
+        account_status (string): account_status
+        role (string): role
+        role_descr (string): role_descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaUser: Managed Object
+
+    Example:
+        user_create(handle, name="test", first_name="firstname",
+                  last_name="lastname", descr="", clear_pwd_history="no",
+                  phone="+91-1234567890", email="test@cisco.com",
+                  pwd="p@ssw0rd", expires="yes",
+                  pwd_life_time="no-password-expire",
+                  expiration="2016-01-13T00:00:00", enc_pwd="",
+                  account_status="active")
+    """
+
+    from ucscsdk.mometa.aaa.AaaUser import AaaUser
+    from ucscsdk.mometa.aaa.AaaUserRole import AaaUserRole
+
+    user_mo = AaaUser(parent_mo_or_dn=ucsc_base_dn,
+                      name=name,
+                      first_name=first_name,
+                      last_name=last_name,
+                      descr=descr,
+                      clear_pwd_history=clear_pwd_history,
+                      phone=phone,
+                      email=email,
+                      pwd=pwd,
+                      expires=expires,
+                      pwd_life_time=pwd_life_time,
+                      expiration=expiration,
+                      enc_pwd=enc_pwd,
+                      account_status=account_status)
+
+    if kwargs:
+        user_mo.set_prop_multiple(**kwargs)
+
+    AaaUserRole(parent_mo_or_dn=user_mo, name=role, descr=role_descr)
+    handle.add_mo(user_mo, True)
+    handle.commit()
+    return user_mo
+
+
+def user_exists(handle, name, **kwargs):
+    """
+    checks if user exists
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        user_exists(handle, name="test", first_name="firstname",
+                  last_name="lastname", descr="", clear_pwd_history="no",
+                  phone="+91-1234567890", email="test@cisco.com",
+                  expires="yes",
+                  pwd_life_time="no-password-expire",
+                  expiration="2016-01-13T00:00:00", enc_pwd="",
+                  account_status="active")
+    """
+
+    dn = ucsc_base_dn + "/user-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def user_modify(handle, name, **kwargs):
+    """
+    modifies user
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        AaaUser: Managed Object
+
+    Raises:
+        ValueError: If AaaUser is not present
+
+    Example:
+        user_modify(handle, name="test", first_name="firstname",
+                  last_name="lastname", descr="", clear_pwd_history="no",
+                  phone="+91-1234567890", email="test@cisco.com",
+                  expires="yes",
+                  pwd_life_time="no-password-expire",
+                  expiration="2016-01-13T00:00:00", enc_pwd="",
+                  account_status="active")
+    """
+
+    dn = ucsc_base_dn + "/user-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("User does not exist.")
+
+    mo.set_prop_multiple(**kwargs)
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def user_delete(handle, name):
+    """
+    deletes user
+
+    Args:
+        handle (UcscHandle)
+        name (string): name
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaUser is not present
+
+    Example:
+        user_delete(handle, name="test")
+
+    """
+
+    dn = ucsc_base_dn + "/user-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("User does not exist.")
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def user_add_role(handle, user_name, name, descr="", **kwargs):
+    """
+    Adds role to an user
+
+    Args:
+        handle (UcscHandle)
+        user_name (string): username
+        name (string): rolename
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaUserRole: Managed object
+
+    Raises:
+        ValueError: If AaaUser is not present
+
+    Example:
+        user_add_role(handle, user_name="test", name="admin")
+    """
+
+    from ucscsdk.mometa.aaa.AaaUserRole import AaaUserRole
+
+    dn = ucsc_base_dn + "/user-" + user_name
+    obj = handle.query_dn(dn)
+    if not obj:
+        raise ValueError("User does not exist.")
+
+    mo = AaaUserRole(parent_mo_or_dn=obj, name=name, descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def user_role_exists(handle, user_name, name, **kwargs):
+    """
+    check if role is already added to user
+
+    Args:
+        handle (UcscHandle)
+        user_name (string): username
+        name (string): rolename
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        user_role_exists(handle, user_name="test", name="admin")
+    """
+
+    user_dn = ucsc_base_dn + "/user-" + user_name
+    dn = user_dn + "/role-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def user_remove_role(handle, user_name, name):
+    """
+    Remove role from user
+
+    Args:
+        handle (UcscHandle)
+        user_name (string): username
+        name (string): rolename
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaUserRole is not present
+
+    Example:
+        user_remove_role(handle, user_name="test", name="admin")
+    """
+
+    user_dn = ucsc_base_dn + "/user-" + user_name
+    dn = user_dn + "/role-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Role is not associated with user.")
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def user_add_locale(handle, user_name, name, descr="", **kwargs):
+    """
+    Adds locale to user
+
+    Args:
+        handle (UcscHandle)
+        user_name (string): username
+        name (string): locale name
+        descr (string): descr
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaUserLocale: Managed Object
+
+    Raises:
+        ValueError: If AaaUser is not present
+
+    Example:
+        user_add_locale(handle, user_name="test", name="testlocale")
+    """
+
+    from ucscsdk.mometa.aaa.AaaUserLocale import AaaUserLocale
+
+    dn = ucsc_base_dn + "/user-" + user_name
+    obj = handle.query_dn(dn)
+    if not obj:
+        raise ValueError("User does not exist.")
+
+    mo = AaaUserLocale(parent_mo_or_dn=obj, name=name, descr=descr)
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def user_locale_exists(handle, user_name, name, **kwargs):
+    """
+    check if locale already added to user
+
+    Args:
+        handle (UcscHandle)
+        user_name (string): username
+        name (string): locale name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        user_locale_exists(handle, user_name="test", name="testlocale")
+    """
+
+    user_dn = ucsc_base_dn + "/user-" + user_name
+    dn = user_dn + "/locale-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def user_remove_locale(handle, user_name, name):
+    """
+    Remove locale from user
+
+    Args:
+        handle (UcscHandle)
+        user_name (string): username
+        name (string): locale name
+
+    Returns:
+        None
+
+    Raises:
+        ValueError: If AaaUserLocale is not present
+
+    Example:
+
+    """
+
+    user_dn = ucsc_base_dn + "/user-" + user_name
+    dn = user_dn + "/locale-" + name
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("Locale is not associated with user.")
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def password_strength_check(handle, descr="", **kwargs):
+    """
+    check pasword strength for locally authenticated user
+
+    Args:
+        handle (UcscHandle)
+        descr (string): description
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaUserEp: Managed Object
+
+    Example:
+        password_strength_check(handle)
+    """
+
+    mo = handle.query_dn(ucsc_base_dn + "/pwd-profile")
+    mo.pwd_strength_check = "yes"
+    mo.descr = descr
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def password_strength_uncheck(handle):
+    """
+    check or un-check pasword strength for locally authenticated user
+
+    Args:
+        handle (UcscHandle)
+
+    Returns:
+        AaaUserEp: Managed Object
+
+    Example:
+        password_strength_uncheck(handle)
+    """
+
+    mo = handle.query_dn(ucsc_base_dn + "/pwd-profile")
+    mo.pwd_strength_check = "no"
+    handle.set_mo(mo)
+    handle.commit()
+    return mo
+
+
+def password_profile_modify(handle, change_interval=None,
+                            no_change_interval=None,
+                            change_during_interval=None, change_count=None,
+                            history_count=None, expiration_warn_time=None,
+                            descr=None, **kwargs):
+    """
+    modfiy passpord profile of locally authenticated user
+
+    Args:
+        handle (UcscHandle)
+        change_interval (number): change interval
+        no_change_interval (number): no change interval
+        change_during_interval (string): ["disable", "enable"]
+        change_count (number): change count
+        history_count (number): history count
+        expiration_warn_time(number): expiration warn time
+        descr (string): description
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        AaaPwdProfile: Managed Object
+
+    Raises:
+        ValueError: If AaaPwdProfile is not present
+
+    Example:
+        password_profile_modify(handle, change_count="2")
+    """
+
+    dn = ucsc_base_dn + "/pwd-profile"
+    mo = handle.query_dn(dn)
+    if not mo:
+        raise ValueError("password profile does not exist.")
+
+    if change_interval:
+        mo.change_interval = change_interval
+    if no_change_interval:
+        mo.no_change_interval = no_change_interval
+    if change_during_interval:
+        mo.change_during_interval = change_during_interval
+    if change_count:
+        mo.change_count = change_count
+    if history_count:
+        mo.history_count = history_count
+    if expiration_warn_time:
+        mo.expiration_warn_time = expiration_warn_time
+    if descr:
+        mo.descr = descr
+
+    if kwargs:
+        mo.set_prop_multiple(**kwargs)
+
+    handle.set_mo(mo)
+    handle.commit()
+    return mo


### PR DESCRIPTION
Admin related operations and its unit tests, which includes:
- user, authdomain, ldap, radius, tacacsplus, snmp, dns, keyring, callhome, core_exporter, syslog, timezone.

Signed-off-by: Parag Shah <parag.may4@gmail.com>