### PR TITLE
Adding network apis and their unit-tests

### DIFF
--- a/tests/network/test_dynamic_vnic_conn_policy.py
+++ b/tests/network/test_dynamic_vnic_conn_policy.py
@@ -1,0 +1,43 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.network.dynamic_vnic_conn_policy import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_dynamic_vnic_conn_policy_create():
+    dynamic_vnic_conn_policy_create(
+        handle, name="test_dynavnic", descr="testing dynavnic")
+    found = dynamic_vnic_conn_policy_exists(handle, name="test_dynavnic")[0]
+    assert_equal(found, True)
+    mo = dynamic_vnic_conn_policy_create(
+        handle, name="test_dynavnic", dynamic_eth="32")
+    assert_equal(mo.dynamic_eth, "32")
+
+
+def test_002_dynamic_vnic_conn_policy_delete():
+    dynamic_vnic_conn_policy_delete(handle, name="test_dynavnic")
+    found = dynamic_vnic_conn_policy_exists(handle, name="test_dynavnic")[0]
+    assert_equal(found, False)

--- a/tests/network/test_ip_pool.py
+++ b/tests/network/test_ip_pool.py
@@ -1,0 +1,48 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.network.ip_pool import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_ip_pool_create():
+    ip_pool_create(handle, name="test_ip_pool", descr="testing ip pool")
+    found = ip_pool_exists(handle, name="test_ip_pool")[0]
+    assert_equal(found, True)
+
+
+def test_002_ip_block_add():
+    ip_block_add(handle, "test_ip_pool", "1.1.1.1", "1.1.1.10",
+                 "255.255.255.0", "1.1.1.254")
+    found = ip_pool_exists(handle, name="test_ip_pool", r_from="1.1.1.1",
+                           to="1.1.1.10", subnet="255.255.255.0",
+                           def_gw="1.1.1.254")[0]
+    assert_equal(found, True)
+
+
+def test_003_ip_pool_remove():
+    ip_pool_remove(handle, name="test_ip_pool")
+    found = ip_pool_exists(handle, name="test_ip_pool")[0]
+    assert_equal(found, False)

--- a/tests/network/test_lan_conn_policy.py
+++ b/tests/network/test_lan_conn_policy.py
@@ -1,0 +1,84 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.network.lan_conn_policy import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_lan_conn_policy_create():
+    lan_conn_policy_create(
+        handle, name="test_lan_con_pol", descr="testing lan")
+    found = lan_conn_policy_exists(handle, name="test_lan_con_pol")[0]
+    assert_equal(found, True)
+
+
+def test_002_lcp_vnic_add():
+    lcp_vnic_add(handle, name="test_vnic",
+                 parent_dn="org-root/lan-conn-pol-test_lan_con_pol",
+                 switch_id="A",
+                 mtu="2240",
+                 adaptor_profile_name="global-SRIOV")
+    found = lcp_vnic_exists(handle, name="test_vnic",
+                            parent_dn="org-root/lan-conn-pol-test_lan_con_pol",
+                            mtu="2240")[0]
+    assert_equal(found, True)
+
+
+def test_004_lcp_iscsi_vnic_add():
+    lcp_iscsi_vnic_add(handle, name="test_iscsiv",
+                       parent_dn="org-root/lan-conn-pol-test_lan_con_pol",
+                       switch_id="A",
+                       vnic_name="test_vnic")
+    found = lcp_iscsi_vnic_exists(
+            handle, name="test_iscsiv",
+            parent_dn="org-root/lan-conn-pol-test_lan_con_pol",
+            vnic_name="test_vnic")[0]
+    assert_equal(found, True)
+
+
+def test_002_lcp_iscsi_vnic_delete():
+    lcp_iscsi_vnic_delete(
+            handle, name="test_iscsiv",
+            parent_dn="org-root/lan-conn-pol-test_lan_con_pol")
+    found = lcp_iscsi_vnic_exists(
+            handle, name="test_iscsiv",
+            parent_dn="org-root/lan-conn-pol-test_lan_con_pol")[0]
+    assert_equal(found, False)
+
+
+def test_003_lcp_vnic_delete():
+    lcp_vnic_delete(
+            handle, name="test_vnic",
+            parent_dn="org-root/lan-conn-pol-test_lan_con_pol")
+    found = lcp_vnic_exists(
+            handle, name="test_vnic",
+            parent_dn="org-root/lan-conn-pol-test_lan_con_pol")[0]
+    assert_equal(found, False)
+
+
+def test_003_lan_conn_policy_delete():
+    lan_conn_policy_delete(handle, name="test_lan_con_pol")
+    found = lan_conn_policy_exists(handle, name="test_lan_con_pol")[0]
+    assert_equal(found, False)

--- a/tests/network/test_mac_pool.py
+++ b/tests/network/test_mac_pool.py
@@ -1,0 +1,42 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.network.mac_pool import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_mac_pool_create():
+    mac_pool_create(handle, name="test_mac_pool", descr="testing macpool",
+                    r_from="00:25:B5:00:00:04", to="00:25:B5:00:00:06")
+    found = mac_pool_exists(handle, name="test_mac_pool",
+                            r_from="00:25:B5:00:00:04",
+                            to="00:25:B5:00:00:06")[0]
+    assert_equal(found, True)
+
+
+def test_002_mac_pool_remove():
+    mac_pool_remove(handle, name="test_mac_pool")
+    found = mac_pool_exists(handle, name="test_mac_pool")[0]
+    assert_equal(found, False)

--- a/tests/network/test_mcast_policy.py
+++ b/tests/network/test_mcast_policy.py
@@ -1,0 +1,42 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.network.mcast_policy import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_mcast_policy_create():
+    mcast_policy_create(handle, name="test_mcast_pol", descr="testing mcast",
+                        querier_ip_addr="10.10.10.1", querier_state="enabled")
+    found = mcast_policy_exists(handle, name="test_mcast_pol",
+                                querier_ip_addr="10.10.10.1",
+                                querier_state="enabled")[0]
+    assert_equal(found, True)
+
+
+def test_002_mcast_policy_delete():
+    mcast_policy_delete(handle, name="test_mcast_pol")
+    found = mcast_policy_exists(handle, name="test_mcast_pol")[0]
+    assert_equal(found, False)

--- a/tests/network/test_nwctrl_policy.py
+++ b/tests/network/test_nwctrl_policy.py
@@ -1,0 +1,48 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.network.nwctrl_policy import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_nwctrl_policy_create():
+    nwctrl_policy_create(handle, name="test_nwctrl_pol", descr="testing nwctr",
+                         cdp="enabled", uplink_fail_action="warning")
+    found = nwctrl_policy_exists(handle, name="test_nwctrl_pol", cdp="enabled",
+                                 uplink_fail_action="warning")[0]
+    assert_equal(found, True)
+
+
+def test_002_nwctrl_policy_modify():
+    nwctrl_policy_create(handle, name="test_nwctrl_pol",
+                         cdp="disabled", forge="deny")
+    mo = nwctrl_policy_get(handle, name="test_nwctrl_pol")
+    assert_equal(mo.cdp, "disabled")
+
+
+def test_003_nwctrl_policy_delete():
+    nwctrl_policy_delete(handle, name="test_nwctrl_pol")
+    found = nwctrl_policy_exists(handle, name="test_nwctrl_pol")[0]
+    assert_equal(found, False)

--- a/tests/network/test_qos_policy.py
+++ b/tests/network/test_qos_policy.py
@@ -1,0 +1,41 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.network.qos import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_qos_policy_add():
+    qos_policy_add(handle, name="test_qos_pol", descr="testing qos",
+                   host_control="full", prio="platinum")
+    found = qos_policy_exists(handle, name="test_qos_pol", host_control="full",
+                              prio="platinum")[0]
+    assert_equal(found, True)
+
+
+def test_002_qos_policy_remove():
+    qos_policy_remove(handle, name="test_qos_pol")
+    found = qos_policy_exists(handle, name="test_qos_pol")[0]
+    assert_equal(found, False)

--- a/tests/network/test_usnic_conn_policy.py
+++ b/tests/network/test_usnic_conn_policy.py
@@ -1,0 +1,43 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.network.usnic_conn_policy import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_usnic_conn_policy_create():
+    usnic_conn_policy_create(
+        handle, name="test_usnic_pol", descr="testing usnic")
+    found = usnic_conn_policy_exists(handle, name="test_usnic_pol")[0]
+    assert_equal(found, True)
+    mo = usnic_conn_policy_create(
+        handle, name="test_usnic_pol", usnic_count="32")
+    assert_equal(mo.usnic_count, "32")
+
+
+def test_002_usnic_conn_policy_delete():
+    usnic_conn_policy_delete(handle, name="test_usnic_pol")
+    found = usnic_conn_policy_exists(handle, name="test_usnic_pol")[0]
+    assert_equal(found, False)

--- a/tests/network/test_vlan.py
+++ b/tests/network/test_vlan.py
@@ -1,0 +1,56 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.network.vlan import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_vlan_create():
+    vlan_create(handle, name="test_vlan_create", id="560",
+                sharing="isolated")
+    found = vlan_exists(handle, name="test_vlan_create", id="560",
+                        sharing="isolated")[0]
+    assert_equal(found, True)
+    vlan_create(handle, name="test_appl_vlan", id="660", vlan_type="appliance",
+                sharing="community")
+    found = vlan_exists(handle, name="test_appl_vlan", id="660",
+                        vlan_type="appliance", sharing="community")[0]
+    assert_equal(found, True)
+
+
+def test_002_vlan_modify():
+    mo = vlan_create(handle, name="test_vlan_create", id="560",
+                     sharing="community")
+    assert_equal(mo.sharing, "community")
+
+
+def test_003_vlan_delete():
+    vlan_delete(handle, name="test_vlan_create")
+    found = vlan_exists(handle, name="test_vlan_create")[0]
+    assert_equal(found, False)
+    vlan_delete(handle, name="test_appl_vlan", vlan_type="appliance")
+    found = vlan_exists(handle, name="test_appl_vlan",
+                        vlan_type="appliance")[0]
+    assert_equal(found, False)

--- a/tests/network/test_vmq_conn_policy.py
+++ b/tests/network/test_vmq_conn_policy.py
@@ -1,0 +1,43 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from ..connection.info import custom_setup, custom_teardown
+from nose.tools import *
+from ucsc_apis.network.vmq_conn_policy import *
+
+handle = None
+
+
+def setup():
+    global handle
+    handle = custom_setup()
+
+
+def teardown():
+    custom_teardown(handle)
+
+
+def test_001_vmq_conn_policy_create():
+    vmq_conn_policy_create(
+        handle, name="test_vmq_con_pol", descr="testing vmq")
+    found = vmq_conn_policy_exists(handle, name="test_vmq_con_pol")[0]
+    assert_equal(found, True)
+    mo = vmq_conn_policy_create(
+        handle, name="test_vmq_con_pol", intr_count="32")
+    assert_equal(mo.intr_count, "32")
+
+
+def test_002_vmq_conn_policy_delete():
+    vmq_conn_policy_delete(handle, name="test_vmq_con_pol")
+    found = vmq_conn_policy_exists(handle, name="test_vmq_con_pol")[0]
+    assert_equal(found, False)

--- a/ucsc_apis/network/__init__.py
+++ b/ucsc_apis/network/__init__.py
@@ -1,0 +1,12 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/ucsc_apis/network/dynamic_vnic_conn_policy.py
+++ b/ucsc_apis/network/dynamic_vnic_conn_policy.py
@@ -1,0 +1,135 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains the methods required for creating Dynamic Vnic
+Connection Policy.
+"""
+from ucscsdk.ucscexception import UcscOperationError
+
+
+def dynamic_vnic_conn_policy_create(handle, name, descr=None, dynamic_eth="54",
+                                    adaptor_profile_name=None,
+                                    protection="protected",
+                                    parent_dn="org-root", **kwargs):
+    """
+    Creates Dynamic vNIC Connection Policy
+
+    Args:
+        handle (UcscHandle)
+        name (string) : Dynamic vNIC connection policy name
+        descr (string): description
+        parent_dn (string) : Dn of org
+        dynamic_eth (string) : Number of dynamic vnics
+        protection (string) : Protection mode
+                    ["protected", "protected-pref-a", "protected-pref-b"]
+        adaptor_profile_name (string) : Adaptor policy
+                    ['global-default', 'global-Linux', 'global-Solaris',
+                     'global-SRIOV', 'global-usNIC', 'global-usNICOrcl',
+                     'global-VMWare', 'global-VMPasThr', 'global-Windows']
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        VnicDynamicConPolicy: Managed Object
+
+    Example:
+        dynamic_vnic_conn_policy_create(handle, name="test_dynavnic",
+                                        descr="testing dynavnic",
+                                        dynamic_eth="32")
+    """
+
+    from ucscsdk.mometa.vnic.VnicDynamicConPolicy import VnicDynamicConPolicy
+
+    obj = handle.query_dn(parent_dn)
+    if not obj:
+        raise UcscOperationError("dynamic_vnic_conn_policy_create",
+                                 "Org %s does not exist" % parent_dn)
+
+    mo = VnicDynamicConPolicy(parent_mo_or_dn=obj,
+                              name=name,
+                              descr=descr,
+                              dynamic_eth=dynamic_eth,
+                              protection=protection,
+                              adaptor_profile_name=adaptor_profile_name)
+
+    mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def dynamic_vnic_conn_policy_get(handle, name, parent_dn="org-root"):
+    """
+    Gets Dynamic vNIC Connection Policy
+    Args:
+        handle (UcscHandle)
+        name (string) : Dynamic vNIC Connection Policy name
+        parent_dn (string) : Dn of org
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+    Returns:
+        VnicDynamicConPolicy: Managed Object OR None
+    Example:
+        dynamic_vnic_conn_policy_get(handle, "test_dynavnic")
+    """
+    dn = parent_dn + '/dynamic-con-' + name
+    return handle.query_dn(dn)
+
+
+def dynamic_vnic_conn_policy_exists(handle, name, parent_dn="org-root",
+                                    **kwargs):
+    """
+    Checks if the given Dynamic vNIC Connection Policy already exists
+    Args:
+        handle (UcscHandle)
+        name (string) : Dynamic vNIC Connection Policy name
+        parent_dn (string) : Dn of org
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+    Returns:
+        (True/False, MO/None)
+    Example:
+        found, mo = dynamic_vnic_conn_policy_exists(handle,
+                                                    name="test_dynavnic",
+                                                    dynamic_eth="32")
+    """
+    mo = dynamic_vnic_conn_policy_get(handle, name, parent_dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def dynamic_vnic_conn_policy_delete(handle, name, parent_dn="org-root"):
+    """
+    Deletes a Dynamic vNIC Connection Policy
+    Args:
+        handle (UcscHandle)
+        name (string) : Dynamic vNIC Connection Policy name
+        parent_dn (string) : Dn of org
+    Returns:
+        None
+    Example:
+        dynamic_vnic_conn_policy_delete(handle, "test_dynavnic")
+    """
+    mo = dynamic_vnic_conn_policy_get(handle, name, parent_dn)
+    if not mo:
+        raise UcscOperationError("dynamic_vnic_conn_policy_delete",
+                                 "Dynamic vNIC Connectivity Policy "
+                                 "does not exist")
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/network/ip_pool.py
+++ b/ucsc_apis/network/ip_pool.py
@@ -1,0 +1,194 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains methods required for creating IP Pools.
+"""
+from ucscsdk.ucscexception import UcscOperationError
+
+
+def ip_pool_create(handle, name, descr=None, parent_dn="org-root", **kwargs):
+    """
+    Creates IP Pool
+
+    Args:
+        handle (UcscHandle)
+        name (string) : IP pool name
+        descr (string): description
+        parent_dn (string) : Dn of org
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        IppoolPool : Managed Object
+    Example:
+        ip_pool_create(handle, "sample_ip_pool", descr="default")
+    """
+    from ucscsdk.mometa.ippool.IppoolPool import IppoolPool
+
+    obj = handle.query_dn(parent_dn)
+    if not obj:
+        raise UcscOperationError("ip_pool_create",
+                                 "Org %s does not exist" % parent_dn)
+    mo = IppoolPool(parent_mo_or_dn=obj,
+                    descr=descr,
+                    name=name)
+
+    mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def ip_block_add(handle, ip_pool_name, r_from, to, subnet, def_gw,
+                 prim_dns="0.0.0.0", sec_dns="0.0.0.0",
+                 scope="public", parent_dn="org-root", **kwargs):
+    """
+    Creates IP Pool block
+
+    Args:
+        handle (UcscHandle)
+        ip_pool_name (string) : Name of the IP Pool
+        r_from (string) : Beginning IP Address
+        to (string) : Ending IP Address
+        subnet (string) : Subnet
+        def_gw (string) : default gateway
+        prim_dns (string): primary DNS server
+        sec_dns (string): secondary DNS server
+        parent_dn (string) : Dn of org
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        IppoolBlock: Managed object
+    Raises:
+        UcscOperationError: If the IP Pool does not exist
+    Example:
+        ip_block_add(handle,ip_pool_name="test_ippool", "1.1.1.1", "1.1.1.10",
+                    "255.255.255.0", "1.1.1.254", parent_dn="org-root"):
+    """
+
+    from ucscsdk.mometa.ippool.IppoolBlock import IppoolBlock
+
+    ip_pool_dn = parent_dn + "/ip-pool-" + ip_pool_name
+
+    obj = handle.query_dn(ip_pool_dn)
+    if not obj:
+        raise UcscOperationError("ip_block_add",
+                                 "IP pool '%s' does not exist", ip_pool_dn)
+
+    mo = IppoolBlock(parent_mo_or_dn=obj,
+                     r_from=r_from,
+                     to=to,
+                     subnet=subnet,
+                     def_gw=def_gw,
+                     prim_dns=prim_dns,
+                     sec_dns=sec_dns,
+                     scope=scope)
+
+    mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, True)
+    handle.commit()
+    return mo
+
+
+def ip_pool_get(handle, name, parent_dn="org-root"):
+    """
+    Gets IP Pool if already exists
+    Args:
+        handle (UcscHandle)
+        name (string) : Network Control Policy Name
+        parent_dn (string) : Dn of org
+    Returns:
+        IppoolPool: Managed Object OR None
+    Example:
+        ip_pool_get(handle, "sample_ip_pool")
+    """
+    dn = parent_dn + '/ip-pool-' + name
+    return handle.query_dn(dn)
+
+
+def ip_pool_exists(handle, name, descr=None,
+                   r_from=None, to=None, subnet=None, def_gw=None,
+                   prim_dns=None, sec_dns=None,
+                   scope=None, parent_dn="org-root"):
+    """
+    Checks if the given IP Pool already exists with the same params
+    Note: For ip_pool exist, both "r_from" and "to" must be provided
+    Args:
+        handle (UcscHandle)
+        name (string) : Network Control Policy Name
+        descr (string) : Description
+        r_from (string) : Beginning IP Address
+        to (string) : Ending IP Address
+        subnet (string) : Subnet
+        def_gw (string) : default gateway
+        prim_dns (string): primary DNS server
+        sec_dns (string): secondary DNS server
+        scope (string) : public or private
+        parent_dn (string) : Dn of org
+    Returns:
+        (True/False, MO/None)
+    Example:
+        ip_pool_exists(handle, "sample_ip_pool",
+                       "192.168.1.1", "192.168.1.10")
+    """
+    mo = ip_pool_get(handle, name, parent_dn)
+    if not mo:
+        return (False, None)
+
+    args = {'descr': descr}
+    if not mo.check_prop_match(**args):
+        return (False, None)
+
+    if r_from and to:
+        mo_1_dn = mo.dn + '/block-' + r_from + '-' + to
+        mo_1 = handle.query_dn(mo_1_dn)
+        if not mo_1:
+            return (False, None)
+        args = {
+            'subnet': subnet,
+            'def_gw': def_gw,
+            'prim_dns': prim_dns,
+            'sec_dns': sec_dns,
+            'scope': scope
+        }
+        mo_exists = mo_1.check_prop_match(**args)
+        return (mo_exists, mo if mo_exists else None)
+    return(True, mo)
+
+
+def ip_pool_remove(handle, name, parent_dn="org-root"):
+    """
+    Removes the specified IP Pool
+    Args:
+        handle (UcscHandle)
+        name (string) : IP Pool Name
+        parent_dn (string) : Dn of the Org
+    Returns:
+        None
+    Raises:
+        UcscOperationError: If the IP Pool does not exist
+    Example:
+        ip_pool_remove(handle, "sample_ip", parent_dn="org-root")
+        ip_pool_remove(handle, "demo_ip_pool", parent_dn="org-root/org-demo")
+    """
+    mo = ip_pool_get(handle, name, parent_dn)
+    if not mo:
+        raise UcscOperationError("ip_pool_remove",
+                                 "IP pool '%s' does not exist" % name)
+
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/network/lan_conn_policy.py
+++ b/ucsc_apis/network/lan_conn_policy.py
@@ -1,0 +1,408 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains the methods required for creating LAN Connectivity Policy.
+"""
+from ucscsdk.ucscexception import UcscOperationError
+
+
+def lan_conn_policy_create(handle, name, descr=None, parent_dn="org-root",
+                           **kwargs):
+    """
+    Creates LAN Connectivity Policy
+
+    Args:
+        handle (UcscHandle)
+        name (string) : LAN Connectivity Policy name
+        descr (string): description
+        parent_dn (string) : Dn of org
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        VnicLanConnPolicy: Managed Object
+    Example:
+        lan_conn_policy_create(handle, "samp_conn_pol2")
+    """
+    from ucscsdk.mometa.vnic.VnicLanConnPolicy import VnicLanConnPolicy
+
+    obj = handle.query_dn(parent_dn)
+    if not obj:
+        raise UcscOperationError("lan_conn_policy_create",
+                                 "Org %s does not exist" % parent_dn)
+
+    mo = VnicLanConnPolicy(parent_mo_or_dn=obj,
+                           name=name,
+                           descr=descr)
+
+    mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def lan_conn_policy_get(handle, name, parent_dn="org-root"):
+    """
+    Gets the given LAN Connectivity Policy if exists
+    Args:
+        handle (UcscHandle)
+        name (string) : LAN Connectivity Policy name
+        parent_dn (string) : Dn of org
+    Returns:
+        VnicLanConnPolicy: Managed Object OR None
+    Example:
+        lan_conn_policy_get(handle, "samp_conn_pol2")
+    """
+    dn = parent_dn + '/lan-conn-pol-' + name
+    return handle.query_dn(dn)
+
+
+def lan_conn_policy_exists(handle, name, parent_dn="org-root", **kwargs):
+    """
+    Checks if the given LAN Connectivity Policy already exists
+    Args:
+        handle (UcscHandle)
+        name (string) : LAN Connectivity Policy name
+        parent_dn (string) : Dn of org
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+    Returns:
+        (True/False, MO/None)
+    Example:
+        lan_conn_policy_exists(handle, "samp_conn_pol2")
+    """
+    mo = lan_conn_policy_get(handle, name, parent_dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def lan_conn_policy_delete(handle, name, parent_dn="org-root"):
+    """
+    Deletes a LAN Connectivity Policy
+    Args:
+        handle (UcscHandle)
+        name (string): LAN Connectivity Policy name
+        parent_dn (string) : Dn of org
+    Returns:
+        None
+    Example:
+        lan_conn_policy_delete(handle, "sample-lan-conpolicy")
+    """
+    mo = lan_conn_policy_get(handle, name, parent_dn)
+    if not mo:
+        raise UcscOperationError("lan_conn_policy_delete",
+                                 "LAN Connectivity Policy does not exist")
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def lcp_vnic_add(handle, name, parent_dn, nw_ctrl_policy_name="global-default",
+                 admin_host_port="ANY", admin_vcon="any",
+                 stats_policy_name="global-default", admin_cdn_name=None,
+                 switch_id="A", pin_to_group_name=None, mtu="1500",
+                 qos_policy_name=None, adaptor_profile_name=None,
+                 cdn_source="vnic-name",
+                 ident_pool_name=None, order="unspecified", nw_templ_name=None,
+                 addr="derived", **kwargs):
+    """
+    Adds vNIC to LAN Connectivity Policy
+
+    Args:
+        handle (UcscHandle)
+        parent_dn (string) : Dn of LAN connectivity policy name
+        name (string) : Name of vnic
+        nw_ctrl_policy_name (string) : Network control policy name
+        admin_host_port (string) : Admin host port placement for vnic
+        admin_vcon (string) : Admin vcon for vnic
+        stats_policy_name (string) : Stats policy name
+        cdn_source (string) : CDN source ['vnic-name', 'user-defined']
+        admin_cdn_name (string) : CDN name
+        switch_id (string): Switch id
+        pin_to_group_name (string) : Pinning group name
+        mtu (string): MTU
+        qos_policy_name (string): Qos policy name
+        adaptor_profile_name (string): Adaptor profile name
+        ident_pool_name (string) : Identity pool name
+        order (string) : Order of the vnic
+        nw_templ_name (string) : Network template name
+        addr (string) : Address of the vnic
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        VnicEther: Managed Object
+
+    Example:
+        lcp_vnic_add(handle, "test_vnic", "org-root/lan-conn-pol-lcp_test_pol",
+                 nw_ctrl_policy_name="test_nwpol", switch_id= "A",mtu="2240",
+                 adaptor_profile_name="global-SRIOV")
+    """
+    from ucscsdk.mometa.vnic.VnicEther import VnicEther
+
+    mo = handle.query_dn(parent_dn)
+    if not mo:
+        raise UcscOperationError("lcp_vnic_add",
+                                 "LAN connectivity policy '%s' does not exist"
+                                 % parent_dn)
+
+    if cdn_source not in ['vnic-name', 'user-defined']:
+        raise UcscOperationError("lcp_vnic_add",
+                                 "Invalid CDN source name")
+
+    admin_cdn_name = "" if cdn_source == "vnic-name" else admin_cdn_name
+
+    mo_1 = VnicEther(parent_mo_or_dn=mo,
+                     name=name,
+                     nw_ctrl_policy_name=nw_ctrl_policy_name,
+                     admin_host_port=admin_host_port,
+                     admin_vcon=admin_vcon,
+                     stats_policy_name=stats_policy_name,
+                     admin_cdn_name=admin_cdn_name,
+                     switch_id=switch_id,
+                     pin_to_group_name=pin_to_group_name,
+                     mtu=mtu,
+                     qos_policy_name=qos_policy_name,
+                     adaptor_profile_name=adaptor_profile_name,
+                     ident_pool_name=ident_pool_name,
+                     order=order,
+                     nw_templ_name=nw_templ_name,
+                     cdn_source=cdn_source,
+                     addr=addr)
+
+    mo_1.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo_1, modify_present=True)
+    handle.commit()
+    return mo_1
+
+
+def lcp_vnic_get(handle, name, parent_dn):
+    """
+    Gets the vNIC under given Lan Connectivity Policy
+    Args:
+        handle (UcscHandle)
+        name (string) : Name of vnic
+        parent_dn (string) : Dn of LAN connectivity policy name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+    Returns:
+        VnicEther: Managed Object OR None
+    Example:
+        lcp_vnic_get(handle, "test_vnic",
+                 "org-root/lan-conn-pol-samp_conn_pol2")
+    """
+    dn = parent_dn + '/ether-' + name
+    return handle.query_dn(dn)
+
+
+def lcp_vnic_exists(handle, name, parent_dn, **kwargs):
+    """
+    Checks if the given vNIC already exists with the same params under a
+    given Lan Connectivity Policy
+    Args:
+        handle (UcscHandle)
+        name (string) : Name of vnic
+        parent_dn (string) : Dn of LAN connectivity policy name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+    Returns:
+        (True/False, MO/None)
+    Example:
+        lcp_vnic_exists(handle, "test_vnic",
+                        "org-root/lan-conn-pol-samp_conn_pol2",
+                        mtu="2240")
+    """
+    mo = lcp_vnic_get(handle, name, parent_dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def lcp_vnic_delete(handle, name, parent_dn):
+    """
+    Remove vNIC from LAN Connectivity Policy
+    Args:
+        handle (UcscHandle)
+        name (string) : Name of vnic
+        parent_dn (string) : Dn of LAN connectivity policy name
+    Returns:
+        None
+    Example:
+        lcp_vnic_delete(handle, "sample-vnic",
+                        "org-root/lan-conn-pol-samp_conn_pol")
+    """
+    mo = lcp_vnic_get(handle, name, parent_dn)
+    if not mo:
+        raise UcscOperationError("lcp_vnic_delete",
+                                 "vnic does not exist")
+
+    handle.remove_mo(mo)
+    handle.commit()
+
+
+def lcp_iscsi_vnic_add(handle, name, parent_dn, addr="derived",
+                       admin_host_port="ANY",
+                       admin_vcon="any", stats_policy_name="global-default",
+                       admin_cdn_name=None, cdn_source="vnic-name",
+                       switch_id="A", pin_to_group_name=None, vnic_name=None,
+                       qos_policy_name=None,
+                       adaptor_profile_name="global-default",
+                       ident_pool_name=None, order="unspecified",
+                       nw_templ_name=None, vlan_name="default",
+                       **kwargs):
+    """
+    Adds iSCSI vNIC to LAN Connectivity Policy
+
+    Args:
+        handle (UcscHandle)
+        parent_dn (string) : Dn of LAN connectivity policy name
+        name (string) : Name of iscsi vnic
+        admin_host_port (string) : Admin host port placement for vnic
+        admin_vcon (string) : Admin vcon for vnic
+        stats_policy_name (string) : Stats policy name
+        cdn_source (string) : CDN source ['vnic-name', 'user-defined']
+        admin_cdn_name (string) : CDN name
+        switch_id (string): Switch id
+        pin_to_group_name (string) : Pinning group name
+        vnic_name (string): Overlay vnic name
+        qos_policy_name (string): Qos policy name
+        adaptor_profile_name (string): Adaptor profile name
+        ident_pool_name (string) : Identity pool name
+        order (string) : Order of the vnic
+        nw_templ_name (string) : Network template name
+        addr (string) : Address of the vnic
+        vlan_name (string): Name of the vlan
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        VnicIScsiLCP : Managed Object
+    Example:
+        lcp_iscsi_vnic_add(handle, "test_iscsi",
+                           "org-root/lan-conn-pol-samppol2",
+                           nw_ctrl_policy_name="test_nwpol", switch_id= "A",
+                           vnic_name="vnic1",
+                           adaptor_profile_name="global-SRIOV")
+    """
+    from ucscsdk.mometa.vnic.VnicIScsiLCP import VnicIScsiLCP
+    from ucscsdk.mometa.vnic.VnicVlan import VnicVlan
+
+    mo = handle.query_dn(parent_dn)
+    if not mo:
+        raise UcscOperationError("lcp_iscsi_vnic_add",
+                                 "LAN connectivity policy '%s' does not exist"
+                                 % parent_dn)
+
+    if cdn_source not in ['vnic-name', 'user-defined']:
+        raise UcscOperationError("lcp_iscsi_vnic_add",
+                                 "Invalid CDN source name")
+
+    admin_cdn_name = "" if cdn_source == "vnic-name" else admin_cdn_name
+    mo_1 = VnicIScsiLCP(parent_mo_or_dn=mo,
+                        addr=addr,
+                        admin_host_port=admin_host_port,
+                        admin_vcon=admin_vcon,
+                        stats_policy_name=stats_policy_name,
+                        cdn_source=cdn_source,
+                        admin_cdn_name=admin_cdn_name,
+                        switch_id=switch_id,
+                        pin_to_group_name=pin_to_group_name,
+                        vnic_name=vnic_name,
+                        qos_policy_name=qos_policy_name,
+                        adaptor_profile_name=adaptor_profile_name,
+                        ident_pool_name=ident_pool_name,
+                        order=order,
+                        nw_templ_name=nw_templ_name,
+                        name=name)
+
+    mo_1.set_prop_multiple(**kwargs)
+
+    VnicVlan(parent_mo_or_dn=mo_1, name="", vlan_name=vlan_name)
+
+    handle.add_mo(mo_1)
+    handle.commit()
+    return mo_1
+
+
+def lcp_iscsi_vnic_get(handle, name, parent_dn):
+    """
+    Gets iSCSI vNIC under a given Lan Connectivity Policy
+    Args:
+        handle (UcscHandle)
+        name (string) : Name of iscsi vnic
+        parent_dn (string) : Dn of LAN connectivity policy name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+    Returns:
+        VnicIScsiLCP : Managed Object OR None
+    Example:
+        lcp_iscsi_vnic_get(handle, "test_iscsi_vnic",
+                       "org-root/lan-conn-pol-samp_conn_pol2")
+    """
+    dn = parent_dn + '/iscsi-' + name
+    return handle.query_dn(dn)
+
+
+def lcp_iscsi_vnic_exists(handle, name, parent_dn, **kwargs):
+    """
+    Checks if the given iSCSI vNIC already exists with the same params
+    under a given Lan Connectivity Policy
+    Args:
+        handle (UcscHandle)
+        name (string) : Name of iscsi vnic
+        parent_dn (string) : Dn of LAN connectivity policy name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+    Returns:
+        (True/False, MO/None)
+    Example:
+        lcp_iscsi_vnic_exists(handle, "org-root/lan-conn-pol-samp_conn_pol2",
+                        "test_iscsi_vnic")
+    """
+    mo = lcp_iscsi_vnic_get(handle, name, parent_dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def lcp_iscsi_vnic_delete(handle, name, parent_dn):
+    """
+    Remove iSCSI vNIC from LAN Connectivity Policy
+    Args:
+        handle (UcscHandle)
+        name (string) : Name of iscsi vnic
+        parent_dn (string) : Dn of LAN connectivity policy name
+    Returns:
+        None
+    Example:
+        lcp_iscsi_vnic_delete(handle, "sample-vnic-iscsi",
+                    "org-root/lan-conn-pol-samp_conn_pol")
+    """
+    mo = lcp_iscsi_vnic_get(handle, name, parent_dn)
+    if not mo:
+        raise UcscOperationError("lcp_iscsi_vnic_delete",
+                                 "iSCSI vnic does not exist")
+
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/network/mac_pool.py
+++ b/ucsc_apis/network/mac_pool.py
@@ -1,0 +1,135 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+This module contains methods required for creating MAC Pools.
+"""
+from ucscsdk.ucscexception import UcscOperationError
+
+
+def mac_pool_create(handle, name, r_from, to, descr=None, parent_dn="org-root",
+                    **kwargs):
+    """
+    Creates MAC Pool
+
+    Args:
+        handle (UcscHandle)
+        name (string) : Mac Pool Name
+        r_from (string) : Beginning MAC Address
+        to (string) : Ending MAC Address
+        descr (string) : description
+        parent_dn (string) : Dn of the Org
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        None
+
+    Example:
+        mac_pool_create(handle, "sample_mac_pool",
+                    "00:25:B5:00:00:00", "00:25:B5:00:00:03")
+    """
+    from ucscsdk.mometa.macpool.MacpoolPool import MacpoolPool
+    from ucscsdk.mometa.macpool.MacpoolBlock import MacpoolBlock
+
+    obj = handle.query_dn(parent_dn)
+    if not obj:
+        raise UcscOperationError("mac_pool_create",
+                                 "Org %s does not exist" % parent_dn)
+
+    mo = MacpoolPool(parent_mo_or_dn=obj,
+                     descr=descr,
+                     name=name)
+
+    mo.set_prop_multiple(**kwargs)
+
+    MacpoolBlock(parent_mo_or_dn=mo,
+                 to=to,
+                 r_from=r_from)
+
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def mac_pool_get(handle, name, parent_dn="org-root"):
+    """
+    Gets the MAC Pool
+    Args:
+        handle (UcscHandle)
+        name (string) : Network Control Policy Name
+        parent_dn (string) : Dn of the Org
+    Returns:
+        (True/False, MO/None)
+    Example:
+        mac_pool_get(handle, "sample_mac_pool")
+    """
+    dn = parent_dn + '/mac-pool-' + name
+    return handle.query_dn(dn)
+
+
+def mac_pool_exists(handle, name, descr=None,
+                    r_from=None, to=None, parent_dn="org-root"):
+    """
+    Checks if the given MAC Pool already exists with the same params
+    Note: For mac_pool exist, both "r_from" and "to" must be provided
+    Args:
+        handle (UcscHandle)
+        name (string) : Network Control Policy Name
+        r_from (string) : Beginning MAC Address
+        to (string) : Ending MAC Address
+        descr (string) : description
+        parent_dn (string) : Dn of the Org
+    Returns:
+        (True/False, MO/None)
+    Example:
+        bool_var = mac_pool_exists(handle, "sample_mac_pool",
+                        "00:25:B5:00:00:00", "00:25:B5:00:00:03")
+    """
+    mo = mac_pool_get(handle, name, parent_dn)
+    if not mo:
+        return (False, None)
+
+    args = {'descr': descr}
+    if not mo.check_prop_match(**args):
+        return (False, None)
+
+    if r_from and to:
+        mo_1_dn = mo.dn + '/block-' + r_from + '-' + to
+        mo_1 = handle.query_dn(mo_1_dn)
+        if not mo_1:
+            return (False, None)
+    return (True, mo)
+
+
+def mac_pool_remove(handle, name, parent_dn="org-root"):
+    """
+    Removes the specified MAC Pool
+    Args:
+        handle (UcscHandle)
+        name (string) : MAC Pool Name
+        parent_dn (string) : Dn of the Org
+    Returns:
+        None
+    Raises:
+        UcscOperationError: If the MAC Pool is not found
+    Example:
+        mac_pool_remove(handle, "sample_mac", parent_dn="org-root")
+        mac_pool_remove(handle, "demo_mac_pool", parent_dn="org-root/org-demo")
+    """
+    mo = mac_pool_get(handle, name, parent_dn)
+    if not mo:
+        raise UcscOperationError("mac_pool_remove",
+                                 "MAC pool %s does not exist" % name)
+
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/network/mcast_policy.py
+++ b/ucsc_apis/network/mcast_policy.py
@@ -1,0 +1,133 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs the create the mulitcast policer under the specified org
+"""
+from ucscsdk.ucscexception import UcscOperationError
+
+
+def mcast_policy_create(handle, name, querier_state="disabled",
+                        snooping_state="disabled",
+                        querier_ip_addr="0.0.0.0",
+                        descr=None, parent_dn="org-root", **kwargs):
+    """
+    Creates Multicast Policy
+
+    Args:
+        handle (UcscHandle)
+        name (string)
+        querier_state (string) : ["disabled", "enabled"]
+        snooping_state (string) : ["disabled", "enabled"]
+        querier_ip_addr (string) : IP address of querier
+        descr (string) : description
+        parent_dn (string) : Dn of org
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        FabricMulticastPolicy: Managed Object
+
+    Example:
+        mcast_policy_create(handle, "my_mcast", "disabled", "enabled")
+    """
+    from ucscsdk.mometa.fabric.FabricMulticastPolicy import \
+        FabricMulticastPolicy
+
+    obj = handle.query_dn(parent_dn)
+    if not obj:
+        raise UcscOperationError("mcast_policy_create",
+                                 "Org %s does not exist" % parent_dn)
+
+    mcast_policy = FabricMulticastPolicy(parent_mo_or_dn=obj,
+                                         querier_ip_addr=querier_ip_addr,
+                                         name=name,
+                                         descr=descr,
+                                         querier_state=querier_state,
+                                         snooping_state=snooping_state)
+
+    mcast_policy.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mcast_policy, modify_present=True)
+    handle.commit()
+    return mcast_policy
+
+
+def mcast_policy_get(handle, name, parent_dn="org-root"):
+    """
+    Gets the mcast policy
+
+    Args:
+        handle (Ucshandle)
+        name (string): Name of the policy
+        parent_dn (string): Dn of org
+
+    Returns:
+        FabricMulticastPolicy: Managed Object OR None
+
+    Example:
+        mcast_policy_get(handle, "demo")
+    """
+    dn = parent_dn + '/mc-policy-' + name
+    return handle.query_dn(dn)
+
+
+def mcast_policy_exists(handle, name, parent_dn="org-root", **kwargs):
+    """
+    Checks if the mcast policy object exists
+
+    Args:
+        handle (Ucshandle)
+        name (string): Name of the policy
+        parent_dn (string): Dn of org
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        bool_var = mcast_policy_exists(handle, "demo")
+        bool_var = mcast_policy_exists(handle, "demo", "org-root/org-demo")
+    """
+    mo = mcast_policy_get(handle, name, parent_dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def mcast_policy_delete(handle, name, parent_dn="org-root"):
+    """
+    Deletes a Multicast Policy
+
+    Args:
+        handle (UcscHandle)
+        name (string): Name of the policy
+        parent_dn (string): Dn of org
+
+    Returns:
+        None
+
+    Example:
+        mcast_policy_delete(handle, "my_mcast")
+        mcast_policy_delete(handle, "my_mcast", "org-root/org-demo")
+    """
+    mo = mcast_policy_get(handle, name, parent_dn)
+    if not mo:
+        raise UcscOperationError("mcast_policy_delete",
+                                 "Mcast policy does not exist")
+
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/network/nwctrl_policy.py
+++ b/ucsc_apis/network/nwctrl_policy.py
@@ -1,0 +1,160 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains methods required for creating network control policies.
+"""
+from ucscsdk.ucscexception import UcscOperationError
+
+
+def nwctrl_policy_create(handle, name, descr=None, cdp="disabled",
+                         mac_register_mode="only-native-vlan",
+                         uplink_fail_action="link-down",
+                         forge="allow", lldp_transmit="disabled",
+                         lldp_receive="disabled", parent_dn="org-root",
+                         **kwargs):
+    """
+    Creates Network Control Policy
+
+    Args:
+        handle (UcscHandle)
+        name (string) : Network Control Policy Name
+        cdp (string) : ["disabled", "enabled"]
+        mac_register_mode (string): ["all-host-vlans", "only-native-vlan"]
+        uplink_fail_action (string) : ["link-down", "warning"]
+        forge (string) : ["allow", "deny"]
+        lldp_transmit (string) : ["disabled", "enabled"]
+        lldp_receive (string) : ["disabled", "enabled"]
+        descr (string) : description
+        parent_dn (string) : Org Dn or Domain_group Dn
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        NwctrlDefinition: Managed Object
+
+    Example:
+        nwctrl_policy_create(handle, "sample_nwcontrol_policy",
+                             "enabled", "all-host-vlans",
+                             "link-down", "allow", "disabled", "disabled")
+    """
+    from ucscsdk.mometa.nwctrl.NwctrlDefinition import NwctrlDefinition
+    from ucscsdk.mometa.dpsec.DpsecMac import DpsecMac
+
+    obj = handle.query_dn(parent_dn)
+    if not obj:
+        raise UcscOperationError("nwctrl_policy_create",
+                                 "Org %s does not exist" % parent_dn)
+
+    mo = NwctrlDefinition(parent_mo_or_dn=obj,
+                          lldp_transmit=lldp_transmit,
+                          name=name,
+                          lldp_receive=lldp_receive,
+                          mac_register_mode=mac_register_mode,
+                          cdp=cdp,
+                          uplink_fail_action=uplink_fail_action,
+                          descr=descr)
+
+    mo.set_prop_multiple(**kwargs)
+
+    DpsecMac(parent_mo_or_dn=mo,
+             forge=forge,
+             name="",
+             descr="")
+
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def nwctrl_policy_get(handle, name, parent_dn="org-root"):
+    """
+    Checks if the given Network Control Policy already exists with the
+    same params
+
+    Args:
+        handle (UcscHandle)
+        name (string) : Network Control Policy Name
+        parent_dn (string) : Org Dn or Domain_group Dn
+
+    Returns:
+        NwctrlDefinition: Managed Object OR None
+    Example:
+        nwctrl_policy_get(handle, "sample_nwcontrol_policy")
+    """
+    dn = parent_dn + '/nwctrl-' + name
+    return handle.query_dn(dn)
+
+
+def nwctrl_policy_exists(handle, name, parent_dn="org-root", **kwargs):
+    """
+    Checks if the given Network Control Policy already exists with the
+    same params
+
+    Args:
+        handle (UcscHandle)
+        name (string) : Network Control Policy Name
+        parent_dn (string) : Org Dn or Domain_group Dn
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+    Returns:
+        (True/False, MO/None)
+    Example:
+        bool_var = nwctrl_policy_exists(handle, "sample_nwcontrol_policy",
+                                        "enabled", "all-host-vlans",
+                                        "link-down", "allow", "disabled",
+                                        "disabled")
+    """
+    mo = nwctrl_policy_get(handle, name, parent_dn)
+    if not mo:
+        return (False, None)
+
+    if "forge" in kwargs:
+        mo_1_dn = mo.dn + "/mac-sec"
+        mo_1 = handle.query_dn(mo_1_dn)
+        if not mo_1:
+            raise UcscOperationError("nwctrl_policy_exists",
+                                     "Mac secure object does not exist")
+
+        args = {'forge': kwargs['forge']}
+        if not mo.check_prop_match(**args):
+            return (False, None)
+
+        kwargs.pop('forge', None)
+
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def nwctrl_policy_delete(handle, name, parent_dn="org-root"):
+    """
+    Deletes a Network Control Policy
+    Args:
+        handle (UcscHandle)
+        name (string) : Network Control Policy Name
+        parent_dn (string) : Org Dn or Domain_group Dn
+    Returns:
+        None
+    Example:
+        nwctrl_policy_delete(handle, "my_nw_policy")
+        nwctrl_policy_delete(handle, "my_nw_policy", "org-root/org-demo")
+    """
+
+    mo = nwctrl_policy_get(handle, name, parent_dn)
+    if not mo:
+        raise UcscOperationError("nwctrl_policy_delete",
+                                 "Network Control policy does not exist")
+
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/network/qos.py
+++ b/ucsc_apis/network/qos.py
@@ -1,0 +1,159 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains methods required for configuring QoS.
+"""
+from ucscsdk.ucscexception import UcscOperationError
+
+
+def qos_policy_add(handle, name, descr=None, prio="best-effort", burst="10240",
+                   rate="line-rate", host_control="none",
+                   parent_dn="org-root", **kwargs):
+    """
+    Creates QoS Policy
+
+    Args:
+        handle (UcscHandle)
+        name (string) : QoS Policy Name
+        descr (string) :
+        prio (string) : Qos class
+                ["best-effort", "bronze", "fc", "gold", "platinum", "silver"]
+        burst (uint): Bytes of burst
+        rate (string) : ["line-rate"], ["8-40000000"] in Kbps
+        host_control (string) : ["full", "none"]
+        parent_dn (string) :
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        EpqosDefinition: Managed object
+
+    Raises:
+        UcscOperationError: If EpqosDefinition is not present
+
+    Example:
+        mo = qos_policy_create(handle, "sample_qos", "platinum", 10240,
+                                "line-rate", "full")
+    """
+    from ucscsdk.mometa.epqos.EpqosDefinition import EpqosDefinition
+    from ucscsdk.mometa.epqos.EpqosEgress import EpqosEgress
+
+    obj = handle.query_dn(parent_dn)
+    if not obj:
+        raise UcscOperationError("qos_policy_create",
+                                 "org '%s' does not exist" % parent_dn)
+
+    mo = EpqosDefinition(parent_mo_or_dn=obj,
+                         name=name,
+                         descr=descr)
+    mo_1 = EpqosEgress(parent_mo_or_dn=mo,
+                       rate=rate,
+                       host_control=host_control,
+                       name="",
+                       prio=prio,
+                       burst=burst)
+
+    mo_1.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def qos_policy_get(handle, name, parent_dn="org-root"):
+    """
+    Checks if the given qos policy already exists with the same params
+
+    Args:
+        handle (UcscHandle)
+        name (string) : QoS Policy Name
+        parent_dn (string) :
+
+    Returns:
+        EpqosDefinition: Managed object OR None
+    Example:
+        qos_policy_get(handle, "sample_qos")
+    """
+    dn = parent_dn + '/ep-qos-' + name
+    return handle.query_dn(dn)
+
+
+def qos_policy_exists(handle, name, parent_dn="org-root", **kwargs):
+    """
+    Checks if the given qos policy already exists with the same params
+
+    Args:
+        handle (UcscHandle)
+        name (string) : QoS Policy Name
+        parent_dn (string) :
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+
+    Returns:
+        (True/False, MO/None)
+
+    Example:
+        bool_var = qos_policy_exists(handle, "sample_qos", "platinum", 10240,
+                                     "line-rate", "full")
+    """
+    mo = qos_policy_get(handle, name, parent_dn)
+
+    if not mo:
+        return (False, None)
+
+    args = {'descr': kwargs['descr'] if 'descr' in kwargs else None}
+    if not mo.check_prop_match(**args):
+        return (False, None)
+    kwargs.pop('descr', None)
+
+    mo_1_dn = mo.dn + '/egress'
+    mo_1 = handle.query_dn(mo_1_dn)
+    if not mo_1:
+        raise UcscOperationError("qos_policy_exists",
+                                 "Egress QoS policy does not exist")
+
+    if not mo_1.check_prop_match(**kwargs):
+        return (False, None)
+
+    return (True, mo)
+
+
+def qos_policy_remove(handle, name, parent_dn="org-root"):
+    """
+    Removes the specified qos policy
+
+    Args:
+        handle (UcscHandle)
+        name (string) : QoS Policy Name
+        parent_dn (string) : Dn of the Org in which the policy should reside
+
+    Returns:
+        None
+
+    Raises:
+        UcscOperationError: If the policy is not found
+
+    Example:
+        qos_policy_remove(handle, "sample_qos", parent_dn="org-root")
+        qos_policy_remove(handle, "demo_qos_policy",
+                          parent_dn="org-root/org-demo")
+    """
+    mo = qos_policy_get(handle, name, parent_dn)
+    if not mo:
+        raise UcscOperationError("qos_policy_remove",
+                                 "Qos Policy does not exist")
+
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/network/usnic_conn_policy.py
+++ b/ucsc_apis/network/usnic_conn_policy.py
@@ -1,0 +1,124 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains the methods required for creating usnic Connection Policy.
+"""
+from ucscsdk.ucscexception import UcscOperationError
+
+
+def usnic_conn_policy_create(handle, name, descr=None, usnic_count="58",
+                             adaptor_profile_name="global-default",
+                             parent_dn="org-root", **kwargs):
+    """
+    Creates usNIC Connection Policy
+
+    Args:
+        handle (UcscHandle)
+        name (string) : usNIC connection policy name
+        descr (string) : description
+        parent_dn (string) : Dn of org
+        usnic_count (string) : Number of usnics
+        adaptor_profile_name (string) : Adaptor policy
+                    ['global-default', 'global-Linux', 'global-Solaris',
+                     'global-SRIOV', 'global-usNIC', 'global-usNICOrcl',
+                     'global-VMWare', 'global-VMPasThr', 'global-Windows']
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        vnicUsnicConPolicy: Managed Object
+
+    Example:
+        usnic_conn_policy_create(handle, "samp_usnic_conn", usnic_count="32",
+                                 adaptor_profile_name="global-usNIC")
+    """
+
+    from ucscsdk.mometa.vnic.VnicUsnicConPolicy import VnicUsnicConPolicy
+
+    obj = handle.query_dn(parent_dn)
+    if not obj:
+        raise UcscOperationError("usnic_conn_policy_create",
+                                 "Org %s does not exist" % parent_dn)
+
+    mo = VnicUsnicConPolicy(parent_mo_or_dn=obj,
+                            name=name,
+                            descr=descr,
+                            usnic_count=usnic_count,
+                            adaptor_profile_name=adaptor_profile_name)
+
+    mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def usnic_conn_policy_get(handle, name, parent_dn="org-root"):
+    """
+    Gets usNIC Connection Policy
+    Args:
+        handle (UcscHandle)
+        name (string) : usNIC Connection Policy name
+        parent_dn (string) : Dn of org
+
+    Returns:
+        vnicUsnicConPolicy: Managed Object OR None
+    Example:
+        usnic_conn_policy_get(handle, "samp_usnic_conn")
+    """
+    dn = parent_dn + '/usnic-con-' + name
+    return handle.query_dn(dn)
+
+
+def usnic_conn_policy_exists(handle, name, parent_dn="org-root", **kwargs):
+    """
+    Checks if the given usNIC Connection Policy already exists
+    Args:
+        handle (UcscHandle)
+        name (string) : usNIC Connection Policy name
+        parent_dn (string) : Dn of org
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+    Returns:
+        (True/False, MO/None)
+    Example:
+        found, mo = usnic_conn_policy_exists(handle, "samp_usnic_conn",
+                                             usnic_count = "32")
+    """
+    mo = usnic_conn_policy_get(handle, name, parent_dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def usnic_conn_policy_delete(handle, name, parent_dn="org-root"):
+    """
+    Deletes a usNIC Connection Policy
+    Args:
+        handle (UcscHandle)
+        name (string) : usNIC Connection Policy name
+        parent_dn (string) : Dn of org
+    Returns:
+        None
+    Example:
+        usnic_conn_policy_delete(handle, "samp_usnic_conn")
+    """
+    mo = usnic_conn_policy_get(handle, name, parent_dn)
+    if not mo:
+        raise UcscOperationError("usnic_conn_policy_delete",
+                                 "usNIC Connectivity Policy does not exist")
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/network/vlan.py
+++ b/ucsc_apis/network/vlan.py
@@ -1,0 +1,151 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module performs the Vlan related operation
+"""
+from ucscsdk.ucscexception import UcscOperationError
+
+
+def vlan_create(handle, name, id, sharing="none", vlan_type="lan",
+                mcast_policy_name=None, compression_type="included",
+                default_net="no", pub_nw_name=None, domain_group="root",
+                **kwargs):
+    """
+    Creates VLAN
+
+    Args:
+        handle (UcscHandle)
+        name (string) : VLAN Name
+        id (string): VLAN ID
+        sharing (string) : Vlan sharing
+                           ["community", "isolated", "none", "primary"]
+        vlan_type (string) : Type of Vlan ["lan", "appliance"]
+        mcast_policy_name (string) : Multicast policy name
+        compression_type (string) : ["excluded", "included"]
+        default_net (string) : ["false", "no", "true", "yes"]
+        pub_nw_name (string) : Name of primary vlan, applicable for isolated
+                               or community vlan
+        domain_group (string) : Full domain group name
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        FabricVlan: Managed Object
+
+    Example:
+        vlan_create(handle, "none", "vlan-lab", "123",  "sample_mcast_policy",
+                    "included")
+    """
+    from ucscsdk.mometa.fabric.FabricVlan import FabricVlan
+    from ucscsdk.utils.ucscdomain import get_domain_group_dn
+
+    domain_group_dn = get_domain_group_dn(handle, domain_group)
+
+    if vlan_type != "lan" and vlan_type != "appliance":
+        raise UcscOperationError("vlan_create",
+                                 "Vlan Type %s does not exist" % vlan_type)
+    vlan_obj_dn = domain_group_dn + "/fabric/lan" if vlan_type == "lan" else \
+        domain_group_dn + "/fabric/eth-estc"
+    obj = handle.query_dn(vlan_obj_dn)
+    if not obj:
+        raise UcscOperationError("vlan_create",
+                                 "Fabric LAN cloud %s does not exist"
+                                 % vlan_obj_dn)
+
+    vlan = FabricVlan(parent_mo_or_dn=obj,
+                      sharing=sharing,
+                      name=name,
+                      id=id,
+                      mcast_policy_name=mcast_policy_name,
+                      default_net=default_net,
+                      pub_nw_name=pub_nw_name,
+                      compression_type=compression_type)
+
+    vlan.set_prop_multiple(**kwargs)
+
+    handle.add_mo(vlan, modify_present=True)
+    handle.commit()
+    return vlan
+
+
+def vlan_get(handle, name, vlan_type="lan", domain_group="root"):
+    """
+    Gets the VLAN
+    Args:
+        handle (UcscHandle)
+        name (string) : VLAN Name
+        vlan_type (string) : Type of Vlan ["lan", "appliance"]
+        domain_group (string) : Full domain group name
+
+    Returns:
+        FabricVlan: Managed Object OR None
+    Example:
+        bool_var = vlan_exists(handle, "none", "vlan-lab", "123",
+                        "sample_mcast_policy", "included")
+    """
+    from ucscsdk.utils.ucscdomain import get_domain_group_dn
+
+    if vlan_type != "lan" and vlan_type != "appliance":
+        raise UcscOperationError("vlan_get",
+                                 "Vlan Type %s does not exist" % vlan_type)
+    domain_group_dn = get_domain_group_dn(handle, domain_group)
+    dn = (domain_group_dn + "/fabric/lan/net-" + name) if vlan_type == "lan" \
+        else (domain_group_dn + "/fabric/eth-estc/net-" + name)
+    return handle.query_dn(dn)
+
+
+def vlan_exists(handle, name, vlan_type="lan", domain_group="root", **kwargs):
+    """
+    Checks if the given VLAN already exists with the same params
+    Args:
+        handle (UcscHandle)
+        name (string) : VLAN Name
+        vlan_type (string) : Type of Vlan ["lan", "appliance"]
+        domain_group (string) : Full domain group name
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+    Returns:
+        (True/False, MO/None)
+    Example:
+        bool_var = vlan_exists(handle, "none", "vlan-lab", "123",
+                        "sample_mcast_policy", "included")
+    """
+    mo = vlan_get(handle, name, vlan_type, domain_group)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def vlan_delete(handle, name, vlan_type="lan", domain_group="root"):
+    """
+    Deletes a VLAN
+    Args:
+        handle (UcscHandle)
+        name (string) : VLAN Name
+        vlan_type (string) : Type of Vlan ["lan", "appliance"]
+        domain_group (string) : Full domain group name
+    Returns:
+        None
+    Example:
+        vlan_delete(handle, "lab-vlan")
+    """
+    mo = vlan_get(handle, name, vlan_type, domain_group)
+    if not mo:
+        raise UcscOperationError("vlan_delete",
+                                 "VLAN does not exist")
+
+    handle.remove_mo(mo)
+    handle.commit()

--- a/ucsc_apis/network/vmq_conn_policy.py
+++ b/ucsc_apis/network/vmq_conn_policy.py
@@ -1,0 +1,120 @@
+# Copyright 2017 Cisco Systems, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+This module contains the methods required for creating VMQ Connection Policy.
+"""
+from ucscsdk.ucscexception import UcscOperationError
+
+
+def vmq_conn_policy_create(handle, name, descr=None, vmq_count="64",
+                           intr_count="64", parent_dn="org-root", **kwargs):
+    """
+    Creates VMQ Connection Policy
+
+    Args:
+        handle (UcscHandle)
+        name (string) : VMQ connection policy name
+        descr (string) : description
+        parent_dn (string) : Dn of org
+        vmq_count (string) : Number of VMQs
+        intr_count (string) : Number of Interrupts
+        **kwargs: Any additional key-value pair of managed object(MO)'s
+                  property and value, which are not part of regular args.
+                  This should be used for future version compatibility.
+    Returns:
+        VnicVmqConPolicy: Managed Object
+
+    Example:
+        vmq_conn_policy_create(handle, "samp_vmq_conn", vmq_count="48",
+                               intr_count="32")
+    """
+
+    from ucscsdk.mometa.vnic.VnicVmqConPolicy import VnicVmqConPolicy
+
+    obj = handle.query_dn(parent_dn)
+    if not obj:
+        raise UcscOperationError("vmq_conn_policy_create",
+                                 "Org %s does not exist" % parent_dn)
+
+    mo = VnicVmqConPolicy(parent_mo_or_dn=obj,
+                          name=name,
+                          descr=descr,
+                          vmq_count=vmq_count,
+                          intr_count=intr_count)
+
+    mo.set_prop_multiple(**kwargs)
+
+    handle.add_mo(mo, modify_present=True)
+    handle.commit()
+    return mo
+
+
+def vmq_conn_policy_get(handle, name, parent_dn="org-root"):
+    """
+    Checks if the given VMQ Connection Policy already exists
+    Args:
+        handle (UcscHandle)
+        name (string) : VMQ Connection Policy name
+        parent_dn (string) : Dn of org
+
+    Returns:
+        VnicVmqConPolicy: Managed Object OR None
+    Example:
+        vmq_conn_policy_get(handle, "samp_vmq_conn")
+    """
+    dn = parent_dn + '/vmq-con-' + name
+    return handle.query_dn(dn)
+
+
+def vmq_conn_policy_exists(handle, name, parent_dn="org-root", **kwargs):
+    """
+    Checks if the given VMQ Connection Policy already exists
+    Args:
+        handle (UcscHandle)
+        name (string) : VMQ Connection Policy name
+        parent_dn (string) : Dn of org
+        **kwargs: key-value pair of managed object(MO) property and value, Use
+                  'print(ucsccoreutils.get_meta_info(<classid>).config_props)'
+                  to get all configurable properties of class
+    Returns:
+        (True/False, MO/None)
+    Example:
+        found, mo = vmq_conn_policy_exists(handle, "samp_vmq_conn",
+                                           intr_count="32")
+    """
+    mo = vmq_conn_policy_get(handle, name, parent_dn)
+    if not mo:
+        return (False, None)
+    mo_exists = mo.check_prop_match(**kwargs)
+    return (mo_exists, mo if mo_exists else None)
+
+
+def vmq_conn_policy_delete(handle, name, parent_dn="org-root"):
+    """
+    Deletes a VMQ Connection Policy
+    Args:
+        handle (UcscHandle)
+        name (string) : VMQ Connection Policy name
+        parent_dn (string) : Dn of org
+    Returns:
+        None
+    Example:
+        vmq_conn_policy_delete(handle, "samp_vmq_conn")
+    """
+    mo = vmq_conn_policy_get(handle, name, parent_dn)
+    if not mo:
+        raise UcscOperationError("vmq_conn_policy_delete",
+                                 "VMQ Connectivity Policy does not exist")
+    handle.remove_mo(mo)
+    handle.commit()


### PR DESCRIPTION
Adding Network related APIs:
- IP pool
- MAC pool
- VLAN
- Multicast policy
- Network control policy
- LAN connectivity policy
- QoS policy
- Dynamic vnic connection policy
- VMQ connection policy
- Usnic connection policy 
 
Signed-off-by: Parag Shah <parag.may4@gmail.com>