### PR TITLE
Renaming some apis and fixing some docstring issues

### DIFF
--- a/tests/admin/test_tacacsplus.py
+++ b/tests/admin/test_tacacsplus.py
@@ -47,8 +47,8 @@ def test_003_tacacsplus_provider_group_create():
     assert_equal(found, True)
 
 
-def test_004_tacacsplus_provider_group_add_provider():
-    tacacsplus_provider_group_add_provider(
+def test_004_tacacsplus_provider_group_provider_add():
+    tacacsplus_provider_group_provider_add(
         handle, group_name="test_prov_grp", name="test_tacac_prov")
     found = tacacsplus_provider_group_provider_exists(
             handle,
@@ -56,15 +56,15 @@ def test_004_tacacsplus_provider_group_add_provider():
     assert_equal(found, True)
 
 
-def test_005_tacacsplus_provider_group_modify_provider():
-    mo = tacacsplus_provider_group_modify_provider(
+def test_005_tacacsplus_provider_group_provider_modify():
+    mo = tacacsplus_provider_group_provider_modify(
         handle, group_name="test_prov_grp", name="test_tacac_prov",
         order="2")
     assert_equal(mo.order, "2")
 
 
-def test_006_tacacsplus_provider_group_remove_provider():
-    tacacsplus_provider_group_remove_provider(
+def test_006_tacacsplus_provider_group_provider_remove():
+    tacacsplus_provider_group_provider_remove(
         handle, group_name="test_prov_grp", name="test_tacac_prov")
     found = tacacsplus_provider_group_provider_exists(
             handle,

--- a/tests/admin/test_timezone.py
+++ b/tests/admin/test_timezone.py
@@ -32,8 +32,8 @@ def test_001_timezone_set():
     assert_equal(mo.timezone, "Asia/Manila")
 
 
-def test_002_ntp_server_create():
-    ntp_server_create(handle, name="192.168.1.1")
+def test_002_ntp_server_add():
+    ntp_server_add(handle, name="192.168.1.1")
     found = ntp_server_exists(handle, name="192.168.1.1")[0]
     assert_equal(found, True)
 

--- a/tests/admin/test_user.py
+++ b/tests/admin/test_user.py
@@ -47,14 +47,14 @@ def test_002_user_modify():
     assert_equal(mo.last_name, "test lastname")
 
 
-def test_003_user_add_role():
-    user_add_role(handle, user_name="test_user", name="storage")
+def test_003_user_role_add():
+    user_role_add(handle, user_name="test_user", name="storage")
     found = user_role_exists(handle, user_name="test_user", name="storage")[0]
     assert_equal(found, True)
 
 
-def test_004_user_remove_role():
-    user_remove_role(handle, user_name="test_user", name="storage")
+def test_004_user_role_remove():
+    user_role_remove(handle, user_name="test_user", name="storage")
     found = user_role_exists(handle, user_name="test_user", name="storage")[0]
     assert_equal(found, False)
 
@@ -65,15 +65,15 @@ def test_005_locale_create():
     assert_equal(found, True)
 
 
-def test_006_user_add_locale():
-    user_add_locale(handle, user_name="test_user", name="testlocale")
+def test_006_user_locale_add():
+    user_locale_add(handle, user_name="test_user", name="testlocale")
     found = user_locale_exists(handle, user_name="test_user",
                                name="testlocale")[0]
     assert_equal(found, True)
 
 
-def test_007_user_remove_locale():
-    user_remove_locale(handle, user_name="test_user", name="testlocale")
+def test_007_user_locale_remove():
+    user_locale_remove(handle, user_name="test_user", name="testlocale")
     found = user_locale_exists(handle, user_name="test_user",
                                name="testlocale")[0]
     assert_equal(found, False)

--- a/ucsc_apis/admin/syslog.py
+++ b/ucsc_apis/admin/syslog.py
@@ -25,7 +25,7 @@ def syslog_local_console_enable(handle, severity="emergencies", **kwargs):
     Args:
         handle (UcscHandle)
         severity (string): Level of logging.
-                           ["alerts", "critical", "emergencies"]
+                        ["emergencies","alerts", "critical"]
         **kwargs: Any additional key-value pair of managed object(MO)'s
                   property and value, which are not part of regular args.
                   This should be used for future version compatibility.
@@ -36,7 +36,7 @@ def syslog_local_console_enable(handle, severity="emergencies", **kwargs):
         UcscOperationError: If CommSyslogConsole is not present
 
     Example:
-        syslog_local_console_enable(handle, severity="alert")
+        syslog_local_console_enable(handle, severity="alerts")
     """
 
     from ucscsdk.mometa.comm.CommSyslogConsole import \
@@ -173,6 +173,8 @@ def syslog_local_file_enable(handle, name=None, severity="emergencies",
         handle (UcscHandle)
         name (string): Name of Log file.
         severity (string): Level of logging.
+                        ["alerts", "critical", "debugging", "emergencies",
+                        "errors", "information", "notifications", "warnings"]
         size (string): Maximum allowed size of log file(In KBs).
         **kwargs: Any additional key-value pair of managed object(MO)'s
                   property and value, which are not part of regular args.
@@ -255,7 +257,6 @@ def syslog_remote_enable(handle, name, hostname="none",
         severity (string): Level of logging.
                         ["alerts", "critical", "debugging", "emergencies",
                         "errors", "information", "notifications", "warnings"]
-
         forwarding_facility (string): Forwarding mechanism local0 to local7.
         **kwargs: Any additional key-value pair of managed object(MO)'s
                   property and value, which are not part of regular args.

--- a/ucsc_apis/admin/tacacsplus.py
+++ b/ucsc_apis/admin/tacacsplus.py
@@ -272,7 +272,7 @@ def tacacsplus_provider_group_delete(handle, name):
     handle.commit()
 
 
-def tacacsplus_provider_group_add_provider(handle, group_name, name,
+def tacacsplus_provider_group_provider_add(handle, group_name, name,
                                            order="lowest-available",
                                            descr=None, **kwargs):
     """
@@ -294,7 +294,7 @@ def tacacsplus_provider_group_add_provider(handle, group_name, name,
         UcscOperationError: If AaaProviderGroup Or AaaProvider is not present
 
     Example:
-        tacacsplus_provider_group_add_provider(handle,
+        tacacsplus_provider_group_provider_add(handle,
                                     group_name="test_prov_grp",
                                     name="test_tacac_prov")
     """
@@ -304,13 +304,13 @@ def tacacsplus_provider_group_add_provider(handle, group_name, name,
     group_dn = ucsc_base_dn + "/tacacs-ext/providergroup-" + group_name
     group_mo = handle.query_dn(group_dn)
     if not group_mo:
-        raise UcscOperationError("tacacsplus_provider_group_add_provider",
+        raise UcscOperationError("tacacsplus_provider_group_provider_add",
                                  "TacacsPlus Provider Group does not exist.")
 
     provider_dn = ucsc_base_dn + "/tacacs-ext/provider-" + name
     mo = handle.query_dn(provider_dn)
     if not mo:
-        raise UcscOperationError("tacacsplus_provider_group_add_provider",
+        raise UcscOperationError("tacacsplus_provider_group_provider_add",
                                  "TacacsPlus Provider does not exist.")
 
     mo = AaaProviderRef(parent_mo_or_dn=group_mo,
@@ -388,7 +388,7 @@ def tacacsplus_provider_group_provider_exists(handle, group_name, name,
     return (mo_exists, mo if mo_exists else None)
 
 
-def tacacsplus_provider_group_modify_provider(handle, group_name, name,
+def tacacsplus_provider_group_provider_modify(handle, group_name, name,
                                               **kwargs):
     """
     modifies a tacacsplus provider added to a tacacsplus provider  group
@@ -408,14 +408,14 @@ def tacacsplus_provider_group_modify_provider(handle, group_name, name,
         UcscOperationError: If AaaProviderRef is not present
 
     Example:
-        tacacsplus_provider_group_modify_provider(
+        tacacsplus_provider_group_provider_modify(
           handle, group_name="test_prov_grp", name="test_tacac_prov",
           order="2")
     """
 
     mo = tacacsplus_provider_group_provider_get(handle, group_name, name)
     if not mo:
-        raise UcscOperationError("tacacsplus_provider_group_modify_provider",
+        raise UcscOperationError("tacacsplus_provider_group_provider_modify",
                                  "Provider not available under group.")
 
     mo.set_prop_multiple(**kwargs)
@@ -424,7 +424,7 @@ def tacacsplus_provider_group_modify_provider(handle, group_name, name,
     return mo
 
 
-def tacacsplus_provider_group_remove_provider(handle, group_name, name):
+def tacacsplus_provider_group_provider_remove(handle, group_name, name):
     """
     removes a tacacsplus provider from a tacacsplus provider  group
 
@@ -440,14 +440,14 @@ def tacacsplus_provider_group_remove_provider(handle, group_name, name):
         UcscOperationError: If AaaProviderRef is not present
 
     Example:
-        tacacsplus_provider_group_remove_provider(handle,
+        tacacsplus_provider_group_provider_remove(handle,
                                     group_name="test_prov_grp",
                                     name="test_tacac_prov")
     """
 
     mo = tacacsplus_provider_group_provider_get(handle, group_name, name)
     if not mo:
-        raise UcscOperationError("tacacsplus_provider_group_remove_provider",
+        raise UcscOperationError("tacacsplus_provider_group_provider_remove",
                                  "Provider not available under group.")
 
     handle.remove_mo(mo)

--- a/ucsc_apis/admin/timezone.py
+++ b/ucsc_apis/admin/timezone.py
@@ -55,7 +55,7 @@ def time_zone_set(handle, timezone, **kwargs):
     return mo
 
 
-def ntp_server_create(handle, name, descr=None, **kwargs):
+def ntp_server_add(handle, name, descr=None, **kwargs):
     """
     Adds NTP server using IP address.
 
@@ -70,7 +70,7 @@ def ntp_server_create(handle, name, descr=None, **kwargs):
         CommNtpProvider: Managed object
 
     Example:
-        ntp_server_create(handle, name="72.163.128.140", descr="Default NTP")
+        ntp_server_add(handle, name="72.163.128.140", descr="Default NTP")
     """
 
     from ucscsdk.mometa.comm.CommNtpProvider import CommNtpProvider

--- a/ucsc_apis/admin/user.py
+++ b/ucsc_apis/admin/user.py
@@ -202,7 +202,7 @@ def user_delete(handle, name):
     handle.commit()
 
 
-def user_add_role(handle, user_name, name, descr=None, **kwargs):
+def user_role_add(handle, user_name, name, descr=None, **kwargs):
     """
     Adds role to an user
 
@@ -221,7 +221,7 @@ def user_add_role(handle, user_name, name, descr=None, **kwargs):
         UcscOperationError: If AaaUser is not present
 
     Example:
-        user_add_role(handle, user_name="test", name="admin")
+        user_role_add(handle, user_name="test", name="admin")
     """
 
     from ucscsdk.mometa.aaa.AaaUserRole import AaaUserRole
@@ -229,7 +229,7 @@ def user_add_role(handle, user_name, name, descr=None, **kwargs):
     dn = ucsc_base_dn + "/user-" + user_name
     obj = handle.query_dn(dn)
     if not obj:
-        raise UcscOperationError("user_add_role",
+        raise UcscOperationError("user_role_add",
                                  "User does not exist.")
 
     mo = AaaUserRole(parent_mo_or_dn=obj, name=name, descr=descr)
@@ -288,7 +288,7 @@ def user_role_exists(handle, user_name, name, **kwargs):
     return (mo_exists, mo if mo_exists else None)
 
 
-def user_remove_role(handle, user_name, name):
+def user_role_remove(handle, user_name, name):
     """
     Remove role from user
 
@@ -304,19 +304,19 @@ def user_remove_role(handle, user_name, name):
         UcscOperationError: If AaaUserRole is not present
 
     Example:
-        user_remove_role(handle, user_name="test", name="admin")
+        user_role_remove(handle, user_name="test", name="admin")
     """
 
     mo = user_role_get(handle, user_name, name)
     if not mo:
-        raise UcscOperationError("user_remove_role",
+        raise UcscOperationError("user_role_remove",
                                  "Role is not associated with user.")
 
     handle.remove_mo(mo)
     handle.commit()
 
 
-def user_add_locale(handle, user_name, name, descr=None, **kwargs):
+def user_locale_add(handle, user_name, name, descr=None, **kwargs):
     """
     Adds locale to user
 
@@ -335,7 +335,7 @@ def user_add_locale(handle, user_name, name, descr=None, **kwargs):
         UcscOperationError: If AaaUser is not present
 
     Example:
-        user_add_locale(handle, user_name="test", name="testlocale")
+        user_locale_add(handle, user_name="test", name="testlocale")
     """
 
     from ucscsdk.mometa.aaa.AaaUserLocale import AaaUserLocale
@@ -343,7 +343,7 @@ def user_add_locale(handle, user_name, name, descr=None, **kwargs):
     dn = ucsc_base_dn + "/user-" + user_name
     obj = handle.query_dn(dn)
     if not obj:
-        raise UcscOperationError("user_add_locale",
+        raise UcscOperationError("user_locale_add",
                                  "User does not exist.")
 
     mo = AaaUserLocale(parent_mo_or_dn=obj, name=name, descr=descr)
@@ -402,7 +402,7 @@ def user_locale_exists(handle, user_name, name, **kwargs):
     return (mo_exists, mo if mo_exists else None)
 
 
-def user_remove_locale(handle, user_name, name):
+def user_locale_remove(handle, user_name, name):
     """
     Remove locale from user
 
@@ -418,12 +418,12 @@ def user_remove_locale(handle, user_name, name):
         UcscOperationError: If AaaUserLocale is not present
 
     Example:
-
+        user_locale_remove(handle, user_name="test", name="testlocale")
     """
 
     mo = user_locale_get(handle, user_name, name)
     if not mo:
-        raise UcscOperationError("user_remove_locale",
+        raise UcscOperationError("user_locale_remove",
                                  "Locale is not associated with user.")
 
     handle.remove_mo(mo)
@@ -432,7 +432,7 @@ def user_remove_locale(handle, user_name, name):
 
 def password_strength_check(handle, descr=None, **kwargs):
     """
-    check pasword strength for locally authenticated user
+    Check password strength for locally authenticated user
 
     Args:
         handle (UcscHandle)
@@ -460,7 +460,7 @@ def password_strength_check(handle, descr=None, **kwargs):
 
 def password_strength_uncheck(handle):
     """
-    check or un-check pasword strength for locally authenticated user
+    check or un-check password strength for locally authenticated user
 
     Args:
         handle (UcscHandle)
@@ -485,16 +485,16 @@ def password_profile_modify(handle, change_interval=None,
                             history_count=None, expiration_warn_time=None,
                             descr=None, **kwargs):
     """
-    modfiy passpord profile of locally authenticated user
+    Modify password profile of locally authenticated user
 
     Args:
         handle (UcscHandle)
-        change_interval (number): change interval
-        no_change_interval (number): no change interval
+        change_interval (string): change interval
+        no_change_interval (string): no change interval
         change_during_interval (string): ["disable", "enable"]
-        change_count (number): change count
-        history_count (number): history count
-        expiration_warn_time(number): expiration warn time
+        change_count (string): change count
+        history_count (string): history count
+        expiration_warn_time(string): expiration warn time
         descr (string): description
         **kwargs: Any additional key-value pair of managed object(MO)'s
                   property and value, which are not part of regular args.


### PR DESCRIPTION
This will fixes some minor issues related to spelling mistakes, renaming some of the APIs and fixing the docstring for some of the APIs.
This will fix issues 6 and 7. It partially fix 5 as well.
*'severity' param in syslog_local_console_enable issue, will be fixed in separate PR as it requires change in MISC-schema.

Signed-off-by: Parag Shah <parag.may4@gmail.com>