### PR TITLE
Adding locale to ldap group map APIs

### DIFF
--- a/tests/admin/test_ldap.py
+++ b/tests/admin/test_ldap.py
@@ -14,6 +14,7 @@
 from ..connection.info import custom_setup, custom_teardown
 from nose.tools import *
 from ucsc_apis.admin.ldap import *
+from ucsc_apis.admin.locale import *
 
 handle = None
 
@@ -41,7 +42,7 @@ def test_002_ldap_provider_modify():
 
 
 def test_003_ldap_provider_configure_rules():
-    mo = ldap_provider_configure_group_rules(
+    mo = ldap_provider_group_rules_configure(
             handle,
             ldap_provider_name="test_ldap_prov", authorization="enable")
     assert_equal(mo.authorization, "enable")
@@ -53,8 +54,8 @@ def test_004_ldap_group_map_create():
     assert_equal(found, True)
 
 
-def test_005_ldap_group_map_add_role():
-    ldap_group_map_add_role(
+def test_005_ldap_group_map_role_add():
+    ldap_group_map_role_add(
         handle, ldap_group_map_name="test_ldap_grp_map", name="storage")
     found = ldap_group_map_role_exists(
             handle,
@@ -62,14 +63,24 @@ def test_005_ldap_group_map_add_role():
     assert_equal(found, True)
 
 
-def test_006_ldap_provider_group_create():
+def test_006_ldap_group_map_locale_add():
+    locale_create(handle, name="locale1")
+    ldap_group_map_locale_add(
+        handle, ldap_group_map_name="test_ldap_grp_map", name="locale1")
+    found = ldap_group_map_locale_exists(
+            handle,
+            ldap_group_map_name="test_ldap_grp_map", name="locale1")[0]
+    assert_equal(found, True)
+
+
+def test_007_ldap_provider_group_create():
     ldap_provider_group_create(handle, name="test_prov_grp")
     found = ldap_provider_group_exists(handle, name="test_prov_grp")[0]
     assert_equal(found, True)
 
 
-def test_007_ldap_provider_group_add_provider():
-    ldap_provider_group_add_provider(
+def test_007_ldap_provider_group_provider_add():
+    ldap_provider_group_provider_add(
         handle, group_name="test_prov_grp", name="test_ldap_prov")
     found = ldap_provider_group_provider_exists(
             handle,
@@ -77,15 +88,15 @@ def test_007_ldap_provider_group_add_provider():
     assert_equal(found, True)
 
 
-def test_008_ldap_provider_group_modify_provider():
-    mo = ldap_provider_group_modify_provider(
+def test_008_ldap_provider_group_provider_modify():
+    mo = ldap_provider_group_provider_modify(
         handle, group_name="test_prov_grp", name="test_ldap_prov",
         order="2")
     assert_equal(mo.order, "2")
 
 
-def test_009_ldap_provider_group_remove_provider():
-    ldap_provider_group_remove_provider(
+def test_009_ldap_provider_group_provider_remove():
+    ldap_provider_group_provider_remove(
         handle, group_name="test_prov_grp", name="test_ldap_prov")
     found = ldap_provider_group_provider_exists(
             handle,
@@ -99,8 +110,8 @@ def test_010_ldap_provider_group_delete():
     assert_equal(found, False)
 
 
-def test_011_ldap_group_map_remove_role():
-    ldap_group_map_remove_role(
+def test_011_ldap_group_map_role_remove():
+    ldap_group_map_role_remove(
         handle, ldap_group_map_name="test_ldap_grp_map", name="storage")
     found = ldap_group_map_role_exists(
             handle,

--- a/tests/admin/test_locale.py
+++ b/tests/admin/test_locale.py
@@ -38,14 +38,14 @@ def test_002_locale_modify():
     assert_equal(mo.descr, "testing locale")
 
 
-def test_003_locale_assign_org():
-    mo = locale_assign_org(handle, locale_name="test_locale",
-                           name="test_org_assign")
+def test_003_locale_org_assign():
+    mo = locale_org_assign(handle, locale_name="test_locale",
+                           name="test_org_assign", org_dn="org-root")
     assert_equal(mo.name, "test_org_assign")
 
 
-def test_004_locale_assign_domaingroup():
-    mo = locale_assign_domaingroup(handle, locale_name="test_locale",
+def test_004_locale_domaingroup_assign():
+    mo = locale_domaingroup_assign(handle, locale_name="test_locale",
                                    name="test_domgrp_asn")
     assert_equal(mo.name, "test_domgrp_asn")
 

--- a/ucsc_apis/admin/authdomain.py
+++ b/ucsc_apis/admin/authdomain.py
@@ -168,6 +168,7 @@ def auth_domain_realm_configure(handle, domain_name, realm="local",
         handle (UcscHandle)
         domain_name (string): auth domain name
         realm (string): realm ["ldap", "local", "none", "radius", "tacacs"]
+                        Use "none" to disable auth
         provider_group (string): provider group name
         name (string): name
         descr (string): description
@@ -256,7 +257,8 @@ def native_auth_default(handle, realm=None, session_timeout=None,
 
     Args:
         handle (UcscHandle)
-        realm (string): realm
+        realm (string): realm ["ldap", "local", "none", "radius", "tacacs"]
+                        Use "none" to disable auth
         session_timeout (string): session_timeout
         refresh_period (string): refresh_period
         provider_group (string): provider_group
@@ -304,7 +306,8 @@ def native_auth_console(handle, realm=None, provider_group=None,
 
     Args:
         handle (UcscHandle)
-        realm (string): realm
+        realm (string): realm ["ldap", "local", "none", "radius", "tacacs"]
+                        Use "none" to disable auth
         provider_group (string): provider_group
         name (string): name
         descr (string): description

--- a/ucsc_apis/admin/locale.py
+++ b/ucsc_apis/admin/locale.py
@@ -153,7 +153,7 @@ def locale_delete(handle, name):
     handle.commit()
 
 
-def locale_assign_org(handle, locale_name, name, org_dn="org-root", descr=None,
+def locale_org_assign(handle, locale_name, name, org_dn="org-root", descr=None,
                       **kwargs):
     """
     assigns a locale to org
@@ -162,7 +162,7 @@ def locale_assign_org(handle, locale_name, name, org_dn="org-root", descr=None,
         handle (UcscHandle)
         locale_name(string): locale name
         name (string): name for the assignment
-        org_dn (string): org_dn
+        org_dn (string): Dn string of the org
         descr (string): descr
         **kwargs: Any additional key-value pair of managed object(MO)'s
                   property and value, which are not part of regular args.
@@ -174,7 +174,7 @@ def locale_assign_org(handle, locale_name, name, org_dn="org-root", descr=None,
         UcscOperationError: If AaaLocale is not present
 
     Example:
-        locale_assign_org(handle, locale_name="test_locale",
+        locale_org_assign(handle, locale_name="test_locale",
                           name="test_org_assign")
     """
 
@@ -182,9 +182,12 @@ def locale_assign_org(handle, locale_name, name, org_dn="org-root", descr=None,
 
     obj = locale_get(handle, locale_name)
     if not obj:
-        raise UcscOperationError("locale_assign_org",
+        raise UcscOperationError("locale_org_assign",
                                  "Locale does not exist")
 
+    if not handle.query_dn(org_dn):
+        raise UcscOperationError("locale_org_assign",
+                                 "org_dn does not exist")
     mo = AaaOrg(parent_mo_or_dn=obj, name=name, org_dn=org_dn, descr=descr)
 
     mo.set_prop_multiple(**kwargs)
@@ -194,7 +197,7 @@ def locale_assign_org(handle, locale_name, name, org_dn="org-root", descr=None,
     return mo
 
 
-def locale_unassign_org(handle, locale_name, name):
+def locale_org_unassign(handle, locale_name, name):
     """
     unassigns a locale from org
 
@@ -210,7 +213,7 @@ def locale_unassign_org(handle, locale_name, name):
         UcscOperationError: If AaaOrg is not present
 
     Example:
-        locale_unassign_org(handle, locale_name="test_locale,
+        locale_org_unassign(handle, locale_name="test_locale,
                             name="org_name")
     """
 
@@ -218,14 +221,14 @@ def locale_unassign_org(handle, locale_name, name):
     dn = locale_dn + "/org-" + name
     mo = handle.query_dn(dn)
     if not mo:
-        raise UcscOperationError("locale_unassign_org",
+        raise UcscOperationError("locale_org_unassign",
                                  "No Org assigned to Locale")
 
     handle.remove_mo(mo)
     handle.commit()
 
 
-def locale_assign_domaingroup(handle, locale_name, name,
+def locale_domaingroup_assign(handle, locale_name, name,
                               domaingroup_dn="domaingroup-root", descr=None,
                               **kwargs):
     """
@@ -235,7 +238,7 @@ def locale_assign_domaingroup(handle, locale_name, name,
         handle (UcscHandle)
         locale_name(string): locale name
         name (string): name for the assignment
-        domaingroup_dn (string): domaingroup_dn
+        domaingroup_dn (string): Dn string of the domaingroup
         descr (string): descr
         **kwargs: Any additional key-value pair of managed object(MO)'s
                   property and value, which are not part of regular args.
@@ -247,7 +250,7 @@ def locale_assign_domaingroup(handle, locale_name, name,
         UcscOperationError: If AaaLocale is not present
 
     Example:
-        locale_assign_domaingroup(handle, locale_name="test_locale",
+        locale_domaingroup_assign(handle, locale_name="test_locale",
                                   name="test_domgrp_asn")
     """
 
@@ -255,9 +258,12 @@ def locale_assign_domaingroup(handle, locale_name, name,
 
     obj = locale_get(handle, locale_name)
     if not obj:
-        raise UcscOperationError("locale_assign_domaingroup",
+        raise UcscOperationError("locale_domaingroup_assign",
                                  "Locale does not exist")
 
+    if not handle.query_dn(domaingroup_dn):
+        raise UcscOperationError("locale_org_assign",
+                                 "domaingroup_dn does not exist")
     mo = AaaDomainGroup(parent_mo_or_dn=obj, name=name,
                         domaingroup_dn=domaingroup_dn, descr=descr)
 
@@ -268,7 +274,7 @@ def locale_assign_domaingroup(handle, locale_name, name,
     return mo
 
 
-def locale_unassign_domaingroup(handle, locale_name, name):
+def locale_domaingroup_unassign(handle, locale_name, name):
     """
     unassigns a locale
 
@@ -285,7 +291,7 @@ def locale_unassign_domaingroup(handle, locale_name, name):
         UcscOperationError: If AaaOrg is not present
 
     Example:
-        locale_unassign_domaingroup(handle, locale_name="test_locale,
+        locale_domaingroup_unassign(handle, locale_name="test_locale,
                                     name="test_domgrp_asn")
     """
 
@@ -293,7 +299,7 @@ def locale_unassign_domaingroup(handle, locale_name, name):
     dn = locale_dn + "/domaingroup-" + name
     mo = handle.query_dn(dn)
     if not mo:
-        raise UcscOperationError("locale_unassign_domaingroup",
+        raise UcscOperationError("locale_domaingroup_unassign",
                                  "No domaingroup assigned to Locale")
 
     handle.remove_mo(mo)


### PR DESCRIPTION
* Adding APIs for  add/remove/get locale to ldap group map.
* Renaming of some apis in locale, ldap and updating docstring for realm in authdomain.
* Adding check for existence of org_dn for locale_org_assign and locale_org_unassign API.

Signed-off-by: Parag Shah <parag.may4@gmail.com>