### PR TITLE
add/modify/delete call home proxy config object

### DIFF
--- a/tests/admin/test_callhome.py
+++ b/tests/admin/test_callhome.py
@@ -51,8 +51,10 @@ def test_004_callhome_config():
 
 
 def test_005_callhome_proxy_config():
-    mo = call_home_proxy_config(handle, url="sch.proxycisco.com", port="80")
-    assert_equal(mo.url, "sch.proxycisco.com")
+    mo = call_home_proxy_config(handle, url="http://sch.proxycisco.com", port="80")
+    assert_equal(mo.url, "http://sch.proxycisco.com")
+    mo = call_home_proxy_config(handle, url="", port="80")
+    assert_equal(mo, None)
 
 
 def test_006_callhome_disable():

--- a/ucsc_apis/admin/callhome.py
+++ b/ucsc_apis/admin/callhome.py
@@ -168,12 +168,14 @@ def call_home_proxy_config(handle, url, port="80", **kwargs):
     Args:
         handle (UcscHandle)
         url (String) : URL for the call home proxy
+                        To clear proxy config, set this as empty string ("")
         port (String) : port number for the call home proxy
+                        To clear proxy config, set this as empty string  ("")
         **kwargs: Any additional key-value pair of managed object(MO)'s
                   property and value, which are not part of regular args.
                   This should be used for future version compatibility.
     Returns:
-        SmartcallhomeHttpProxy : ManagedObject
+        SmartcallhomeHttpProxy : ManagedObject or None
 
     Raises:
         UcscOperationError: If SmartcallhomeHttpProxy is not present
@@ -182,15 +184,19 @@ def call_home_proxy_config(handle, url, port="80", **kwargs):
         call_home_proxy_config(handle, url="www.testproxy.com", port=80)
     """
 
-    mo = handle.query_dn(ucsc_base_dn + "/call-home/proxy")
-    if not mo:
-        raise UcscOperationError("call_home_proxy_config",
-                                 "call home proxy is not available.")
-
-    mo.url = url
-    mo.port = port
+    from ucscsdk.mometa.smartcallhome.SmartcallhomeHttpProxy import \
+            SmartcallhomeHttpProxy
+    mo = SmartcallhomeHttpProxy(parent_mo_or_dn=ucsc_base_dn + "/call-home",
+                                url=url,
+                                port=port)
 
     mo.set_prop_multiple(**kwargs)
+
+    if url == "" or port == "":
+        mo.port = None
+        handle.remove_mo(mo)
+        handle.commit()
+        return
 
     handle.add_mo(mo, modify_present=True)
     handle.commit()


### PR DESCRIPTION
Callhome proxy config object can be added/modified or deleted instead of just updating it.
So putting the fix for that.

This will fix the https://github.com/CiscoUcs/ucsc_apis/issues/14

Signed-off-by: Parag Shah <parag.may4@gmail.com>